### PR TITLE
feat(infra): instalação Windows com bootstrap.ps1 e PMW-Tools em wwwroot

### DIFF
--- a/Atualizar_PMW.ps1
+++ b/Atualizar_PMW.ps1
@@ -1,4 +1,4 @@
-# ============================================================
+﻿# ============================================================
 # Atualizar_PMW.ps1
 # Baixa o último release do GitHub e instala na pasta informada
 # Com backup automático e preservação de appsettings.json

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -1,4 +1,4 @@
-# PMW - Project Manager Web - Bootstrap de instalação (Windows)
+﻿# PMW - Project Manager Web - Bootstrap de instalação (Windows)
 # Uso (PowerShell como administrador):
 #   irm https://raw.githubusercontent.com/wallaceSW11/ProjectManagerWeb/main/bootstrap.ps1 -OutFile "$env:TEMP\bootstrap.ps1"; & "$env:TEMP\bootstrap.ps1"
 #

--- a/infra/pmw.ps1
+++ b/infra/pmw.ps1
@@ -1,4 +1,4 @@
-# ============================================================
+﻿# ============================================================
 # PMW - Project Manager Web - Script de gerenciamento (Windows)
 # ============================================================
 # Diretórios:
@@ -142,7 +142,7 @@ function Install-PMW {
     Write-Host "   Scripts de infra em $PMW_TOOLS"
     Write-Host ""
     Write-Host "   Use 'pmw start' para iniciar."
-    Write-Host "   Ou: powershell -File "$PMW_TOOLS\pmw.ps1" start"
+    Write-Host "   Ou: powershell -File ""$PMW_TOOLS\pmw.ps1"" start"
 }
 
 function Update-PMW {


### PR DESCRIPTION
## O que mudou

###  (novo)
Equivalente Windows do  — instalação completa do zero:
- Deteta Windows, eleva para admin se necessário
- Se já existe instalação: pergunta se quer atualizar, para o processo, faz backup
- Busca último release no GitHub, baixa, extrai em 
- Executa  (configura , adiciona ao PATH)
- Inicia o PMW automaticamente

### 
- : cria diretório da aplicação se não existir
- : parada direta do processo (sem dupla detecção)
- PMW-Tools agora em 

### , , , 
Caminhos atualizados de  → 

### Correções de bugs
- Aspas não escapadas na linha 145 do  (parser error) — corrigido com 
- UTF-8 sem BOM nos 3  (caracteres acentuados quebrados no Windows PowerShell 5.1) — adicionado BOM

## Como testar
