### PR TITLE
fix(linux): ajuste no link simbólico do comando pmw no PATH

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -116,9 +116,13 @@ chmod +x "$PMW_DIR/ProjectManagerWeb" 2>/dev/null
 chown -R "$USER:$USER" "$PMW_DIR"
 
 # ------------------------------------------------------------------
-# 7. Inicia o serviço automaticamente
+# 7. Garante o link simbólico e inicia o serviço
 # ------------------------------------------------------------------
 echo ""
+echo "🔗 Garantindo link simbólico..."
+sudo ln -sf "$PMW_TOOLS/pmw.sh" /usr/local/bin/pmw
+hash -r 2>/dev/null || true
+
 echo "🚀 Iniciando PMW..."
 if command -v pmw &>/dev/null; then
   pmw start

--- a/infra/pmw.sh
+++ b/infra/pmw.sh
@@ -52,10 +52,8 @@ case "$1" in
     # Ajusta permissões dos scripts
     chmod +x "$PMW_TOOLS/pmw.sh"
 
-    # Cria link simbólico para o comando pmw (se não existir)
-    if [ ! -L "/usr/local/bin/pmw" ]; then
-      sudo ln -s "$PMW_TOOLS/pmw.sh" /usr/local/bin/pmw
-    fi
+    # Cria link simbólico para o comando pmw (recria se perdido)
+    sudo ln -sf "$PMW_TOOLS/pmw.sh" /usr/local/bin/pmw
 
     # Instala o systemd service
     mkdir -p ~/.config/systemd/user/
@@ -105,19 +103,27 @@ case "$1" in
     chmod +x "$PMW_DIR/ProjectManagerWeb" 2>/dev/null
     chown -R "$USER:$USER" "$PMW_DIR"
 
+    # Garante que o diretório de tools existe
+    mkdir -p "$PMW_TOOLS"
+
     # Atualiza scripts de infra (se o pacote tiver a pasta infra)
     if [ -d "$PMW_DIR/infra" ]; then
       echo "Atualizando scripts de infra em $PMW_TOOLS ..."
-      cp "$PMW_DIR/infra/pmw.service" "$PMW_TOOLS/" 2>/dev/null
-      cp "$PMW_DIR/infra/pmw.sh" "$PMW_TOOLS/" 2>/dev/null
+      cp "$PMW_DIR/infra/pmw.service" "$PMW_TOOLS/"
+      cp "$PMW_DIR/infra/pmw.sh" "$PMW_TOOLS/"
       chmod +x "$PMW_TOOLS/pmw.sh"
-
-      # Atualiza o systemd service
-      cp "$PMW_TOOLS/pmw.service" ~/.config/systemd/user/
-      systemctl --user daemon-reload
 
       # Remove a pasta infra do diretório da aplicação (já está em tools)
       rm -rf "$PMW_DIR/infra"
+    fi
+
+    # Atualiza o systemd service
+    cp "$PMW_TOOLS/pmw.service" ~/.config/systemd/user/
+    systemctl --user daemon-reload
+
+    # Recria o link simbólico se não existir
+    if [ ! -L "/usr/local/bin/pmw" ]; then
+      sudo ln -s "$PMW_TOOLS/pmw.sh" /usr/local/bin/pmw
     fi
 
     # Limpa temporários


### PR DESCRIPTION
## O que mudou

### `infra/pmw.sh` e `bootstrap.sh`
O comando `pmw` estava sendo perdido do PATH no Linux após atualização ou reinstalação. A causa era o link simbólico em `/usr/local/bin/pmw` não ser recriado durante `update`.

### Correções
- **`pmw.sh install`**: link agora é sempre recriado (`ln -sf`) em vez de apenas se não existir
- **`pmw.sh update`**: adicionado `mkdir -p $PMW_TOOLS` e recriação do link se perdido
- **`bootstrap.sh`**: adicionado `ln -sf` e `hash -r` para o shell reconhecer o comando imediatamente

## Como testar
1. Remover o link: `sudo rm /usr/local/bin/pmw`
2. Executar `pmw update` (ou reinstalar via bootstrap)
3. Verificar que `pmw` volta a funcionar: `pmw status`