### PR TITLE
fix(infra): corrige sintaxe no pmw.sh e força Node.js 24 nos workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ develop, main ]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build-frontend:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
 permissions:
   contents: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   bump-version:
     runs-on: ubuntu-latest

--- a/infra/pmw.sh
+++ b/infra/pmw.sh
@@ -108,7 +108,10 @@ case "$1" in
 
     # Obtém URL do último release do GitHub
     REPO_URL="wallaceSW11/ProjectManagerWeb"
-    LATEST_URL=$(curl -s "https://api.github.com/repos/$REPO_URL/releases/latest" | grep -oP '"browser_download_url":\s*"\K[^"]+' | grep -i linux | head -1)
+    API_URL="https://api.github.com/repos/$REPO_URL/releases/latest"
+    LATEST_JSON=$(curl -s "$API_URL")
+    LATEST_URL=$(echo "$LATEST_JSON" | grep "browser_download_url.*Linux" | head -1 | cut -d '"' -f 4)
+    LATEST_TAG=$(echo "$LATEST_JSON" | grep '"tag_name"' | head -1 | cut -d '"' -f 4)
 
     if [ -z "$LATEST_URL" ]; then
       echo "Erro: não foi possível obter a URL do release."


### PR DESCRIPTION
## O que mudou

### `infra/pmw.sh`
Simplificada a busca do último release: trocado `grep -oP` com regex complexa (que quebrava com EOF inesperado em algumas versões do bash) por `grep + cut`, igual ao `bootstrap.sh`.

### `.github/workflows/release.yml` e `ci.yml`
Adicionado `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` como `env` global para eliminar os warnings de depreciação do Node.js 20 nas actions.

## Como testar
- `bash -n infra/pmw.sh` — sem erros
- PR aberto: checar se os 3 warnings de Node.js 20 sumiram da aba Actions