### PR TITLE
feat: backup banco, correção versão release, validação CI e revisor de infra

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,28 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  validate-infra:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validar scripts Bash
+        run: |
+          echo "Validando scripts Bash..."
+          for f in bootstrap.sh infra/pmw.sh; do
+            echo -n "  $f: "
+            bash -n "$f" && echo "OK" || exit 1
+          done
+
+      - name: Validar scripts PowerShell
+        run: |
+          echo "Validando scripts PowerShell..."
+          for f in bootstrap.ps1 Atualizar_PMW.ps1 infra/pmw.ps1; do
+            echo -n "  $f: "
+            pwsh -NoProfile -NoLogo -Command "& { \$tokens = \$errors = \$null; \$ast = [System.Management.Automation.Language.Parser]::ParseFile('$f', [ref]\$tokens, [ref]\$errors); if (\$errors.Count -gt 0) { Write-Error \"ERRO: \$(\$errors[0])\"; exit 1 } else { Write-Host 'OK' } }" || exit 1
+          done
+
   build-frontend:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,26 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  validate-infra:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validar scripts Bash
+        run: |
+          for f in bootstrap.sh infra/pmw.sh; do
+            echo -n "  $f: "
+            bash -n "$f" && echo "OK" || exit 1
+          done
+
+      - name: Validar scripts PowerShell
+        run: |
+          for f in bootstrap.ps1 Atualizar_PMW.ps1 infra/pmw.ps1; do
+            echo -n "  $f: "
+            pwsh -NoProfile -NoLogo -Command "& { \$tokens = \$errors = \$null; \$ast = [System.Management.Automation.Language.Parser]::ParseFile('$f', [ref]\$tokens, [ref]\$errors); if (\$errors.Count -gt 0) { Write-Error \"ERRO: \$(\$errors[0])\"; exit 1 } else { Write-Host 'OK' } }" || exit 1
+          done
+
   bump-version:
     runs-on: ubuntu-latest
     outputs:

--- a/.opencode/agents/infra-reviewer.md
+++ b/.opencode/agents/infra-reviewer.md
@@ -1,0 +1,71 @@
+---
+description: >-
+  Revisor de scripts de infraestrutura (bootstrap, pmw.sh, pmw.ps1, etc).
+  Ativado quando scripts de instalação/atualização são modificados.
+  Valida sintaxe, caminhos, compatibilidade Linux+Windows.
+mode: subagent
+model: deepseek/deepseek-v4-pro
+permission:
+  edit: allow
+  bash: allow
+  task:
+    "*": deny
+color: "#dc3545"
+---
+
+Você é um revisor sênior de scripts shell e PowerShell, especialista em infraestrutura do PMW.
+
+## Responsabilidade
+
+Revisar **TODA** alteração nos scripts de infraestrutura com atenção máxima. Um erro aqui quebra a instalação e atualização em todas as máquinas.
+
+## Arquivos sob sua responsabilidade
+
+- `bootstrap.sh` — instalação Linux do zero
+- `bootstrap.ps1` — instalação Windows do zero
+- `infra/pmw.sh` — gerenciamento Linux (start, stop, install, update)
+- `infra/pmw.ps1` — gerenciamento Windows (start, stop, install, update)
+- `infra/pmw.service` — systemd user service
+- `Atualizar_PMW.ps1` — atualização legada Windows
+
+## Checklist de revisão (obrigatória)
+
+Antes de aprovar qualquer mudança, verifique:
+
+### Sintaxe
+- `bash -n bootstrap.sh` e `bash -n infra/pmw.sh` → zero erros
+- `pwsh -NoProfile -Command "& { Parse script }"` nos `.ps1` → zero erros
+
+### Caminhos e diretórios
+- Linux: `/opt/pmw`, `/opt/pmw-tools`, `/opt/pmw-bkps`
+- Windows: derivados de `Split-Path $Pasta -Parent`
+- Nenhum path hardcoded (ex: `C:\PMW-backup-*` — isso já foi corrigido, não reintroduza)
+
+### Backup
+- Estrutura: `PMW-Bkps/YYYYMMDD_HHMMSS/app/` e `.../banco/`
+- Banco no Windows: `$env:APPDATA\PMW\Banco`
+- Banco no Linux: `~/.config/PMW/Banco` (fallback `~/.local/share/PMW/Banco`)
+
+### Sistema
+- `systemctl --user` (nunca `systemctl` sem `--user`)
+- `$SERVICE_NAME` sempre com `$` (nunca `SERVICE_NAME` solto)
+- `case/esac` com `;;` em todos os branches
+
+### Compatibilidade
+- Funciona em Linux e Windows
+- Funciona com bash e PowerShell 5+
+- Trata erros de rede (curl/Invoke-RestMethod com timeout/try-catch)
+
+## Fluxo de trabalho
+
+1. Leia os arquivos modificados por completo
+2. Leia `infra/README.md`
+3. Rode validação de sintaxe
+4. Verifique cada item da checklist
+5. Reporte problemas encontrados
+
+## Proibições
+
+- NUNCA aprove mudança sem validar sintaxe
+- NUNCA ignore warnings de caminho ou variável não definida
+- NUNCA faça commit de script quebrado

--- a/.opencode/plugins/validate-infra.js
+++ b/.opencode/plugins/validate-infra.js
@@ -1,0 +1,80 @@
+const ARQUIVOS_INFRA = [
+  "bootstrap.sh",
+  "bootstrap.ps1",
+  "Atualizar_PMW.ps1",
+  "infra/pmw.sh",
+  "infra/pmw.ps1",
+  "infra/pmw.service",
+];
+
+function ehArquivoInfra(caminho) {
+  return ARQUIVOS_INFRA.some(a => caminho.endsWith(a) || caminho.replace(/\\/g, "/").endsWith(a));
+}
+
+async function validarBash(caminho) {
+  const proc = Bun.spawn(["bash", "-n", caminho], { stdout: "pipe", stderr: "pipe" });
+  const output = await new Response(proc.stderr).text();
+  await proc.exited;
+  return { ok: proc.exitCode === 0, erro: output.trim() };
+}
+
+async function validarPowerShell(caminho) {
+  const cmd = `& { $tokens = $errors = $null; $ast = [System.Management.Automation.Language.Parser]::ParseFile('${caminho.replace(/'/g, "''")}', [ref]$tokens, [ref]$errors); if ($errors.Count -gt 0) { Write-Error $errors[0].Message; exit 1 } }`;
+  const proc = Bun.spawn(["pwsh", "-NoProfile", "-NoLogo", "-Command", cmd], { stdout: "pipe", stderr: "pipe" });
+  const output = await new Response(proc.stderr).text();
+  await proc.exited;
+  return { ok: proc.exitCode === 0, erro: output.trim() };
+}
+
+export default async () => ({
+  "tool.execute.after": async (input, _output) => {
+    if (input.tool !== "write" && input.tool !== "apply_patch") return;
+
+    const caminho = input.args?.path || input.args?.filePath;
+    if (!caminho || !ehArquivoInfra(caminho)) return;
+
+    const avisos = [];
+    const ext = caminho.split(".").pop()?.toLowerCase();
+
+    if (ext === "sh") {
+      const result = await validarBash(caminho);
+      if (!result.ok)
+        avisos.push(`ERRO CRÍTICO: Sintaxe bash inválida em ${caminho}. O script NÃO vai rodar.
+  ${result.erro}`);
+      else
+        console.log(`[infra] ${caminho}: bash -n OK`);
+    }
+
+    if (ext === "ps1") {
+      const result = await validarPowerShell(caminho);
+      if (!result.ok)
+        avisos.push(`ERRO CRÍTICO: Sintaxe PowerShell inválida em ${caminho}. O script NÃO vai rodar.
+  ${result.erro}`);
+      else
+        console.log(`[infra] ${caminho}: pwsh parse OK`);
+    }
+
+    if (avisos.length > 0) {
+      const feedback = [
+        "========================================",
+        " ATENÇÃO: SCRIPTS DE INFRA MODIFICADOS",
+        "========================================",
+        "",
+        "Estes scripts são a porta de entrada do PMW. Um erro aqui impede",
+        "instalação e atualização em TODAS as máquinas (Linux + Windows).",
+        "",
+        "Revise com atenção antes de commitar:",
+        "  1. Leia infra/README.md com a checklist de revisão",
+        "  2. Teste em VM/container Linux limpo",
+        "  3. Teste em Windows limpo",
+        "",
+        ...avisos,
+        "",
+        "NÃO faça commit se houver ERRO CRÍTICO acima.",
+        "Use o agente @infra-reviewer para revisão detalhada.",
+        "========================================",
+      ].join("\n");
+      console.log(feedback);
+    }
+  }
+});

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,78 @@
+# Infraestrutura PMW — Scripts de instalação e atualização
+
+## Pontos críticos
+
+Estes scripts são a porta de entrada do PMW. Um erro aqui impede instalação e atualização em **todas** as máquinas. Revise com atenção redobrada.
+
+## Estrutura de diretórios
+
+```
+/opt/pmw/                  ← binários da aplicação (Linux)
+/opt/pmw-tools/            ← scripts de infra (pmw.sh, pmw.service)
+/opt/pmw-bkps/             ← backups de atualização
+  └── YYYYMMDD_HHMMSS/
+      ├── app/             ← backup dos binários
+      └── banco/           ← backup dos dados JSON
+
+C:\inetpub\wwwroot\
+  ├── PMW\                 ← binários (Windows)
+  ├── PMW-Tools\           ← scripts de infra
+  └── PMW-Bkps\            ← backups
+```
+
+## Arquivos
+
+| Arquivo | SO | Função | Chamado por |
+|---------|-----|--------|-------------|
+| `bootstrap.sh` | Linux | Instalação do zero (`curl pipe bash`) | Usuário |
+| `bootstrap.ps1` | Windows | Instalação do zero | Usuário |
+| `pmw.sh` | Linux | Gerenciamento (`start/stop/restart/status/logs/install/update`) | `bootstrap.sh`, comando `pmw` |
+| `pmw.ps1` | Windows | Gerenciamento (`start/stop/restart/status/install/update`) | `bootstrap.ps1`, comando `pmw` |
+| `pmw.service` | Linux | Systemd user service | `pmw.sh install` |
+| `Atualizar_PMW.ps1` | Windows | Atualização legada | Usuário (script independente) |
+| `pmw-start.vbs` | Windows | Inicia sem console visível | Atalho/autostart |
+| `pmw-start.bat` | Windows | Atalho para o .vbs | Usuário |
+
+## Fluxo de instalação (Linux)
+
+```
+curl bootstrap.sh | bash
+  → baixa último release do GitHub
+  → extrai em /opt/pmw
+  → chama pmw.sh install
+      → sudo mkdir /opt/pmw, /opt/pmw-tools, /opt/pmw-bkps
+      → copia pmw.sh e pmw.service para /opt/pmw-tools
+      → sudo ln -s /opt/pmw-tools/pmw.sh → /usr/local/bin/pmw
+      → systemctl --user enable pmw
+  → pmw start
+```
+
+## Fluxo de atualização (Linux)
+
+```
+pmw update
+  → systemctl --user stop pmw
+  → backup: PMW-Bkps/YYYYMMDD_HHMMSS/{app,banco}
+  → curl último release → unzip em /opt/pmw
+  → copia novos scripts de infra para /opt/pmw-tools
+  → systemctl --user start pmw
+```
+
+## Checklist de revisão
+
+Ao modificar qualquer script de infra, verifique:
+
+- [ ] `bash -n bootstrap.sh` e `bash -n infra/pmw.sh` passam sem erros
+- [ ] `pwsh -NoProfile -Command "& { ...Parser::ParseFile... }"` nos `.ps1`
+- [ ] Testar `bootstrap.sh` em Linux limpo (VM ou container)
+- [ ] Testar `pmw update` em Linux com instalação existente
+- [ ] Testar `bootstrap.ps1` em Windows limpo
+- [ ] Testar `pmw.ps1 update` em Windows com instalação existente
+- [ ] Caminhos de backup (`PMW-Bkps`) são criados corretamente
+- [ ] Backup do banco (`%APPDATA%/PMW/Banco` ou `~/.config/PMW/Banco`) funciona
+- [ ] O serviço reinicia corretamente após update
+- [ ] A versão exibida no app confere com a tag do release
+
+## CI
+
+Os workflows `ci.yml` (PR) e `release.yml` (push na main) validam sintaxe de todos os `.sh` e `.ps1` antes do build. Um PR com script quebrado **não passa** no CI.

--- a/opencode.json
+++ b/opencode.json
@@ -9,7 +9,8 @@
     ".opencode/code-style/frontend.md"
   ],
   "plugin": [
-    ".opencode/plugins/validate-code-style.js"
+    ".opencode/plugins/validate-code-style.js",
+    ".opencode/plugins/validate-infra.js"
   ],
   "shell": "pwsh",
   "formatter": true,


### PR DESCRIPTION
## O que mudou

### `infra/pmw.sh`, `infra/pmw.ps1`, `bootstrap.*`, `Atualizar_PMW.ps1`
- Nova estrutura de backup: `PMW-Bkps/YYYYMMDD_HHMMSS/{app,banco}/`
- Backup do banco de dados JSON junto com os binários
- Caminhos de `PMW-Tools` e `PMW-Bkps` agora derivam do diretório pai (não hardcoded)
- Simplificado `grep` de busca do release (evita erro de sintaxe EOF)

### `.github/workflows/release.yml`
- Corrigida race condition: jobs de build agora fazem checkout com `ref: main` (binário compilava com versão errada)
- Adicionado job `validate-infra` que valida sintaxe de todos os scripts antes do build
- Adicionado `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true`

### `.github/workflows/ci.yml`
- Adicionado job `validate-infra` (bash -n + pwsh parse)
- Adicionado `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true`

### `frontend/src/App.vue`
- Removida marca d'água "Compilado em:" (versão já aparece no menu)

### `infra/README.md` (NOVO)
- Documentação completa dos scripts de instalação/atualização
- Checklist de revisão para evitar subir scripts quebrados

### `.opencode/plugins/validate-infra.js` (NOVO)
- Plugin que valida sintaxe bash/pwsh automaticamente ao editar scripts de infra

### `.opencode/agents/infra-reviewer.md` (NOVO)
- Agente revisor especializado em scripts de infraestrutura

### Correções de bugs
- Versão exibia 0.0.2 mesmo com release v1.0.1 (race condition no CI)
- Script pmw.sh quebrava com EOF inesperado no grep de release
- Warnings de Node.js 20 deprecated nos workflows

## Como testar
- Abrir um PR: CI deve passar no job `validate-infra`
- Linux: `curl bootstrap.sh | bash` → verificar `PMW-Bkps` criado
- `pmw update` → verificar backup em `PMW-Bkps/data/app/` e `.../banco/`
- Acessar http://localhost:2025 → versão no menu deve bater com tag do release