### PR TITLE
fix(terminals): add signal trapping to command execution in Ghostty and Ptyxis terminals

### DIFF
--- a/backend/src/Utils/Terminais/GhosttyTerminal.cs
+++ b/backend/src/Utils/Terminais/GhosttyTerminal.cs
@@ -11,7 +11,7 @@ public class GhosttyTerminal : ITerminalEmulator
         Process.Start(new ProcessStartInfo
         {
             FileName = "ghostty",
-            Arguments = $"-e bash -l -i -c \"{EscapeBash(trimmed)}; exec bash\"",
+            Arguments = $"-e bash -l -i -c \"trap '' INT; (trap - INT; {EscapeBash(trimmed)}); exec bash\"",
             UseShellExecute = false
         });
     }

--- a/backend/src/Utils/Terminais/PtyxisTerminal.cs
+++ b/backend/src/Utils/Terminais/PtyxisTerminal.cs
@@ -12,11 +12,11 @@ public class PtyxisTerminal : ITerminalEmulator
         if (!string.IsNullOrWhiteSpace(perfilTerminal))
         {
             var uuid = ResolverUuidPerfil(perfilTerminal);
-            args = $"--tab-with-profile=\"{uuid}\" -- bash -l -i -c \"{EscapeBash(trimmed)}; exec bash\"";
+            args = $"--tab-with-profile=\"{uuid}\" -- bash -l -i -c \"trap '' INT; (trap - INT; {EscapeBash(trimmed)}); exec bash\"";
         }
         else
         {
-            args = $"--tab -- bash -l -i -c \"{EscapeBash(trimmed)}; exec bash\"";
+            args = $"--tab -- bash -l -i -c \"trap '' INT; (trap - INT; {EscapeBash(trimmed)}); exec bash\"";
         }
 
         Process.Start(new ProcessStartInfo


### PR DESCRIPTION
## O que mudou

### `backend/src/Utils/Terminais/PtyxisTerminal.cs` e `backend/src/Utils/Terminais/GhosttyTerminal.cs`
Ao executar comandos no Linux via terminal (Ptyxis/Ghostty), o Ctrl+C estava fechando a aba do terminal em vez de apenas interromper o comando e manter o shell aberto.

**Causa raiz:** Os terminais executavam `bash -l -i -c "comando; exec bash"`. Quando o usuário pressionava Ctrl+C, o `bash -c` recebia SIGINT e podia interromper a execução antes de alcançar o `exec bash$, fechando o terminal.

**Correção:** Adicionamos duas camadas de proteção:
1. `trap '' INT` no shell principal — impede que o `bash -c` morra com Ctrl+C
2. Subshell `(trap - INT; comando)` — restaura o handler padrão de SIGINT para que o Ctrl+C interrompa o comando normalmente (seja `dotnet run$, `pnpm start` ou qualquer outro)
3. `exec bash` no final — sempre executado, mantendo o terminal aberto

### Correções de bugs
- Terminal do frontend (`pnpm start`/vite) fechava com Ctrl+C — agora permanece aberto
- Terminal do backend (`dotnet run`) já funcionava, mas agora a solução é mais robusta para qualquer comando

## Como testar
1. Pelo PMW, execute comandos que abrem terminais (ex: "Iniciar" no frontend e backend)
2. Pressione Ctrl+C durante a execução
3. O comando deve parar e o terminal deve permanecer aberto com um shell pronto para novos comandos
4. Testar tanto `dotnet run` quanto `pnpm start`/vite