### PR TITLE
feat: melhorias em formulários, autocomplete e git ignore

### DIFF
--- a/backend/src/Services/ComandoService.cs
+++ b/backend/src/Services/ComandoService.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using ProjectManagerWeb.src.DTOs;
 using ProjectManagerWeb.src.Utils;
 using ProjectManagerWeb.src.Enuns;
@@ -169,7 +170,7 @@ public class ComandoService(RepositorioJsonService repositorioJsonService, IDEJs
                 ShellExecute.LogComando($"File.Copy \"{a.Arquivo}\" -> \"{caminhoArquivoDestino}\"", "OK");
 
                 if (a.IgnorarGit)
-                    IgnorarArquivoNoGit(diretorioDestino, nomeArquivo);
+                    IgnorarArquivoNoGit(caminhoArquivoDestino);
             }
             catch (Exception ex)
             {
@@ -222,12 +223,61 @@ public class ComandoService(RepositorioJsonService repositorioJsonService, IDEJs
             CopiarDiretorioRecursivo(subDir, Path.Combine(destino, Path.GetFileName(subDir)));
     }
 
-    private static void IgnorarArquivoNoGit(string diretorio, string nomeArquivo)
+    private static void IgnorarArquivoNoGit(string caminhoArquivo)
     {
         try
         {
-            var comando = $"cd \"{diretorio}\"; git update-index --assume-unchanged {nomeArquivo}; Exit;";
-            ShellExecute.ExecutarComando(comando);
+            var diretorioArquivo = Path.GetDirectoryName(caminhoArquivo)!;
+
+            var inicioProcesso = new ProcessStartInfo
+            {
+                FileName = "git",
+                Arguments = $"-C \"{diretorioArquivo}\" rev-parse --show-toplevel",
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            using var processo = Process.Start(inicioProcesso);
+            if (processo is null) return;
+
+            var raizGit = processo.StandardOutput.ReadToEnd().Trim();
+            processo.WaitForExit();
+
+            if (string.IsNullOrEmpty(raizGit) || processo.ExitCode != 0) return;
+
+            var caminhoRelativo = Path.GetRelativePath(raizGit, caminhoArquivo).Replace('\\', '/');
+
+            var gitIgnorePath = Path.Combine(raizGit, ".gitignore");
+
+            var estaRastreado = false;
+            var verificaRastreado = new ProcessStartInfo
+            {
+                FileName = "git",
+                Arguments = $"-C \"{raizGit}\" ls-files --error-unmatch \"{caminhoRelativo}\"",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            using var procVerifica = Process.Start(verificaRastreado);
+            if (procVerifica is not null)
+            {
+                procVerifica.WaitForExit();
+                estaRastreado = procVerifica.ExitCode == 0;
+            }
+
+            if (estaRastreado)
+            {
+                var comando = $"cd \"{raizGit}\"; git update-index --assume-unchanged \"{caminhoRelativo}\"; Exit;";
+                ShellExecute.ExecutarComando(comando);
+            }
+            else
+            {
+                var entrada = $"{caminhoRelativo}{Environment.NewLine}";
+                File.AppendAllText(gitIgnorePath, entrada);
+            }
         }
         catch
         {

--- a/frontend/src/components/comum/CadastroTabela.vue
+++ b/frontend/src/components/comum/CadastroTabela.vue
@@ -59,7 +59,10 @@
 
       <!-- FORM -->
       <v-tabs-window-item>
-        <v-form ref="formRef">
+        <v-form
+          ref="formRef"
+          autocomplete="off"
+        >
           <component
             v-for="(field, i) in formFields"
             :key="i"

--- a/frontend/src/components/pastas/PastaCadastro.vue
+++ b/frontend/src/components/pastas/PastaCadastro.vue
@@ -174,11 +174,10 @@
       adicionarNoLocalStorage.value = true;
       await nextTick(() => (adicionarNoLocalStorage.value = false));
 
-      exibirModalPasta.value = false;
-      Object.assign(pasta, new PastaModel());
       notificar('sucesso', 'Pasta cadastrada');
       atualizarListaPastas();
-      limparCampos();
+      exibirModalPasta.value = false;
+      nextTick(() => formPasta.value.resetValidation());
     } catch (error) {
       console.error('Falha ao criar pasta:', error);
       notificar('erro', 'Falha ao criar pasta');

--- a/frontend/src/components/pastas/PastaCadastro.vue
+++ b/frontend/src/components/pastas/PastaCadastro.vue
@@ -7,12 +7,16 @@
       <v-card-title>Cadastrar pasta</v-card-title>
 
       <v-card-text class="pt-0">
-        <v-form ref="formPasta">
+        <v-form
+          ref="formPasta"
+          autocomplete="off"
+        >
           <v-text-field
             label="Diretório"
             v-model="pasta.diretorio"
             :rules="obrigatorio"
             disabled
+            autocomplete="off"
           />
 
           <SelectRepositorio
@@ -32,12 +36,14 @@
             class="uppercase-input"
             hint="Extraído automaticamente do nome da pasta"
             persistent-hint
+            autocomplete="off"
           />
           <v-text-field
             label="Descrição"
             v-model="pasta.descricao"
             hint="Opcional"
             persistent-hint
+            autocomplete="off"
           />
 
           <v-radio-group

--- a/frontend/src/components/repositorios/MenuCadastro.vue
+++ b/frontend/src/components/repositorios/MenuCadastro.vue
@@ -228,6 +228,7 @@
   import { useModoOperacao } from '@/composables/useModoOperacao';
   import ArquivoModel from '@/models/ArquivoModel';
   import PastaMenuModel from '@/models/PastaMenuModel';
+  import { notificar } from '@/utils/eventBus';
 
   const {
     emModoCadastro,
@@ -392,9 +393,14 @@
       if (emModoCadastro.value) {
         adicionarMenu();
         limparCampos();
-        nextTick(() => campoTitulo.value?.focus());
+        notificar('sucesso', 'Menu cadastrado');
+        nextTick(() => {
+          formProjeto.value.resetValidation();
+          campoTitulo.value?.focus();
+        });
       } else {
         atualizarProjeto();
+        notificar('sucesso', 'Menu atualizado');
         descartarAlteracoes();
       }
     } catch (error) {
@@ -414,6 +420,7 @@
         Object.assign(menuSelecionado.arquivos[indice], arquivoSelecionado);
       }
 
+      notificar('sucesso', 'Arquivo atualizado');
       arquivoEmEdicao.value = false;
       limparCamposArquivos();
       mudarParaPaginaTabela();
@@ -421,8 +428,12 @@
     }
 
     menuSelecionado.arquivos.push(new ArquivoModel(arquivoSelecionado));
+    notificar('sucesso', 'Arquivo cadastrado');
     limparCamposArquivos();
-    nextTick(() => campoArquivo.value?.focus());
+    nextTick(() => {
+      formArquivo.value.resetValidation();
+      campoArquivo.value?.focus();
+    });
   };
 
   const salvarAlteracoesPastas = async (): Promise<void> => {
@@ -437,6 +448,7 @@
         Object.assign(menuSelecionado.pastas[indice], pastaSelecionada);
       }
 
+      notificar('sucesso', 'Pasta de menu atualizada');
       pastaEmEdicao.value = false;
       limparCamposPastas();
       mudarParaPaginaTabela();
@@ -444,8 +456,12 @@
     }
 
     menuSelecionado.pastas.push(new PastaMenuModel(pastaSelecionada));
+    notificar('sucesso', 'Pasta de menu cadastrada');
     limparCamposPastas();
-    nextTick(() => campoPastaOrigem.value?.focus());
+    nextTick(() => {
+      formPasta.value.resetValidation();
+      campoPastaOrigem.value?.focus();
+    });
   };
 
   const adicionarMenu = (): void => {

--- a/frontend/src/components/repositorios/MenuCadastro.vue
+++ b/frontend/src/components/repositorios/MenuCadastro.vue
@@ -54,12 +54,16 @@
         >
           <v-tabs-window v-model="paginaMenu">
             <v-tabs-window-item>
-              <v-form ref="formProjeto">
+              <v-form
+                ref="formProjeto"
+                autocomplete="off"
+              >
                 <v-text-field
                   ref="campoTitulo"
                   label="Título"
                   v-model="menuSelecionado.titulo"
                   :rules="obrigatorio"
+                  autocomplete="off"
                 />
 
                 <v-select
@@ -174,18 +178,23 @@
             </v-tabs-window-item>
 
             <v-tabs-window-item>
-              <v-form ref="formArquivo">
+              <v-form
+                ref="formArquivo"
+                autocomplete="off"
+              >
                 <v-text-field
                   ref="campoArquivo"
                   label="Arquivo"
                   v-model="arquivoSelecionado.arquivo"
                   :rules="obrigatorio"
+                  autocomplete="off"
                 />
                 <v-text-field
                   label="Destino"
                   v-model="arquivoSelecionado.destino"
                   hint="Caminho relativo ao repositório"
                   persistent-hint
+                  autocomplete="off"
                 />
                 <v-checkbox
                   label="Ignorar no git diff"
@@ -195,7 +204,10 @@
             </v-tabs-window-item>
 
             <v-tabs-window-item>
-              <v-form ref="formPasta">
+              <v-form
+                ref="formPasta"
+                autocomplete="off"
+              >
                 <v-text-field
                   ref="campoPastaOrigem"
                   label="Pasta Origem"
@@ -203,12 +215,14 @@
                   :rules="obrigatorio"
                   hint="Caminho completo da pasta que será copiada (ex: C:\tools\.kiro)"
                   persistent-hint
+                  autocomplete="off"
                 />
                 <v-text-field
                   label="Destino"
                   v-model="pastaSelecionada.destino"
                   hint="Onde colar a pasta, relativo ao repositório. Vazio = raiz (ex: [nome_git]\frontend)"
                   persistent-hint
+                  autocomplete="off"
                 />
               </v-form>
             </v-tabs-window-item>

--- a/frontend/src/components/repositorios/PerfilMarcacaoCadastro.vue
+++ b/frontend/src/components/repositorios/PerfilMarcacaoCadastro.vue
@@ -131,6 +131,7 @@
   import PerfilMarcacaoProjetoModel from '@/models/PerfilMarcacaoProjetoModel';
   import { useModoOperacao } from '@/composables/useModoOperacao';
   import { TIPO_COMANDO } from '@/constants/geral-constants';
+  import { notificar } from '@/utils/eventBus';
 
   interface Props {
     repositorios: IRepositorio[];
@@ -270,8 +271,12 @@
     if (emModoCadastro.value) {
       repositorio.value.perfis.push(new PerfilMarcacaoModel(perfilSelecionado));
       Object.assign(perfilSelecionado, new PerfilMarcacaoModel());
+      notificar('sucesso', 'Perfil cadastrado');
       inicializarComandosSelecionados();
-      nextTick(() => campoNome.value?.focus());
+      nextTick(() => {
+        formPerfil.value.resetValidation();
+        campoNome.value?.focus();
+      });
     } else {
       const indice = repositorio.value.perfis.findIndex(
         p => p.identificador === perfilSelecionado.identificador
@@ -281,6 +286,7 @@
           repositorio.value.perfis[indice],
           new PerfilMarcacaoModel(perfilSelecionado)
         );
+      notificar('sucesso', 'Perfil atualizado');
       descartarAlteracoes();
     }
   };

--- a/frontend/src/components/repositorios/PerfilMarcacaoCadastro.vue
+++ b/frontend/src/components/repositorios/PerfilMarcacaoCadastro.vue
@@ -43,13 +43,17 @@
       :acaoBotaoSecundario="descartarAlteracoes"
       larguraMinima="600px"
     >
-      <v-form ref="formPerfil">
+      <v-form
+        ref="formPerfil"
+        autocomplete="off"
+      >
         <v-text-field
           ref="campoNome"
           label="Nome do perfil"
           v-model="perfilSelecionado.nome"
           :rules="obrigatorio"
           placeholder="Ex: Iniciar tudo, Só IDE, Build completo"
+          autocomplete="off"
         />
       </v-form>
 

--- a/frontend/src/components/repositorios/ProjetoCadastro.vue
+++ b/frontend/src/components/repositorios/ProjetoCadastro.vue
@@ -43,16 +43,21 @@
         :acaoBotaoPrimario="salvarAlteracoes"
         :acaoBotaoSecundario="descartarAlteracoes"
       >
-        <v-form ref="formProjeto">
+        <v-form
+          ref="formProjeto"
+          autocomplete="off"
+        >
           <v-text-field
             ref="campoNome"
             label="Nome"
             v-model="projetoSelecionado.nome"
             :rules="obrigatorio"
+            autocomplete="off"
           />
           <v-text-field
             label="Subdiretório"
             v-model="projetoSelecionado.subdiretorio"
+            autocomplete="off"
           />
           <v-select
             :items="configuracaoStore.perfisVSCode"
@@ -65,6 +70,7 @@
           <v-text-field
             label="Comando para abrir o arquivo coverage"
             v-model="projetoSelecionado.arquivoCoverage"
+            autocomplete="off"
           />
 
           <h2>Comandos:</h2>
@@ -73,10 +79,12 @@
           <v-text-field
             :label="TIPO_COMANDO.INSTALAR.titulo"
             v-model="projetoSelecionado.comandosObj!.instalar"
+            autocomplete="off"
           />
           <v-text-field
             :label="TIPO_COMANDO.INICIAR.titulo"
             v-model="projetoSelecionado.comandosObj!.iniciar"
+            autocomplete="off"
           />
           <SelectPerfilTerminal
             v-model="projetoSelecionado.perfilTerminal"
@@ -85,6 +93,7 @@
           <v-text-field
             :label="TIPO_COMANDO.BUILDAR.titulo"
             v-model="projetoSelecionado.comandosObj!.buildar"
+            autocomplete="off"
           />
           <v-select
             label="IDE para abrir"

--- a/frontend/src/components/repositorios/ProjetoCadastro.vue
+++ b/frontend/src/components/repositorios/ProjetoCadastro.vue
@@ -112,6 +112,7 @@
   import { TIPO_COMANDO } from '@/constants/geral-constants';
   import IDEsService from '@/services/IDEsService';
   import SelectPerfilTerminal from '@/components/comum/SelectPerfilTerminal.vue';
+  import { notificar } from '@/utils/eventBus';
 
   const repositorio = defineModel<IRepositorio>({ required: true });
   const configuracaoStore = useConfiguracaoStore();
@@ -186,9 +187,14 @@
       if (emModoCadastro.value) {
         adicionarProjeto();
         limparCampos();
-        nextTick(() => campoNome.value?.focus());
+        notificar('sucesso', 'Projeto cadastrado');
+        nextTick(() => {
+          formProjeto.value.resetValidation();
+          campoNome.value?.focus();
+        });
       } else {
         atualizarProjeto();
+        notificar('sucesso', 'Projeto atualizado');
         descartarAlteracoes();
       }
     } catch (error) {

--- a/frontend/src/components/repositorios/RepositorioCadastro.vue
+++ b/frontend/src/components/repositorios/RepositorioCadastro.vue
@@ -144,12 +144,15 @@
   const campoUrl = ref<InstanceType<
     typeof import('vuetify/components').VTextField
   > | null>(null);
+  const formRepositorio = ref<InstanceType<
+    typeof import('vuetify/components').VForm
+  > | null>(null);
 
   function focarUrl(): void {
     nextTick(() => campoUrl.value?.focus());
   }
 
-  defineExpose({ focarUrl });
+  defineExpose({ focarUrl, formRepositorio });
 
   const pastasCentralizadoras = computed(() => {
     return configuracaoStore.pastasCentralizadoras?.map(p => p.nome) || [];

--- a/frontend/src/components/repositorios/TarefasCadastro.vue
+++ b/frontend/src/components/repositorios/TarefasCadastro.vue
@@ -49,6 +49,7 @@
               label="Iniciais"
               density="compact"
               variant="underlined"
+              autocomplete="off"
             />
           </v-col>
           <v-col cols="7">

--- a/frontend/src/components/repositorios/TarefasCadastro.vue
+++ b/frontend/src/components/repositorios/TarefasCadastro.vue
@@ -334,16 +334,17 @@
           ...codigoTarefaForm
         });
       }
+      notificar('sucesso', 'Código de tarefa atualizado');
     } else {
       if (!repositorio.value.codigosTarefa) {
         repositorio.value.codigosTarefa = [];
       }
       repositorio.value.codigosTarefa.push({ ...codigoTarefaForm });
+      notificar('sucesso', 'Código de tarefa cadastrado');
     }
 
     exibirModalCodigoTarefa.value = false;
     codigoTarefaEditandoId.value = null;
-    notificar('sucesso', 'Código de tarefa salvo');
   };
 
   const removerCodigoTarefa = (item: ICodigoTarefa): void => {

--- a/frontend/src/components/repositorios/menuItemCadastro/MenuItemArquivoCadastro.vue
+++ b/frontend/src/components/repositorios/menuItemCadastro/MenuItemArquivoCadastro.vue
@@ -56,15 +56,20 @@
       </v-tabs-window-item>
 
       <v-tabs-window-item>
-        <v-form ref="formProjeto">
+        <v-form
+          ref="formProjeto"
+          autocomplete="off"
+        >
           <v-text-field
             label="Arquivo"
             v-model="arquivoSelecionado.arquivo"
             :rules="obrigatorio"
+            autocomplete="off"
           />
           <v-text-field
             label="Destino"
             v-model="arquivoSelecionado.destino"
+            autocomplete="off"
           />
           <v-checkbox
             label="Ignorar no git diff"

--- a/frontend/src/components/repositorios/menuItemCadastro/MenuItemPastaCadastro.vue
+++ b/frontend/src/components/repositorios/menuItemCadastro/MenuItemPastaCadastro.vue
@@ -56,13 +56,17 @@
       </v-tabs-window-item>
 
       <v-tabs-window-item>
-        <v-form ref="formPasta">
+        <v-form
+          ref="formPasta"
+          autocomplete="off"
+        >
           <v-text-field
             label="Pasta Origem"
             v-model="pastaSelecionada.origem"
             :rules="obrigatorio"
             hint="Caminho completo da pasta que será copiada (ex: C:\__Arquivos_Wallace__\AmazonQ\kiro\.kiro)"
             persistent-hint
+            autocomplete="off"
           />
           <v-text-field
             label="Destino"
@@ -70,6 +74,7 @@
             :rules="obrigatorio"
             hint="Onde colar a pasta, relativo ao repositório (ex: [nome_git]\frontend)"
             persistent-hint
+            autocomplete="off"
           />
         </v-form>
       </v-tabs-window-item>

--- a/frontend/src/components/sitesiis/PastasCadastro.vue
+++ b/frontend/src/components/sitesiis/PastasCadastro.vue
@@ -123,9 +123,10 @@
 </template>
 
 <script setup lang="ts">
-  import { reactive, ref } from 'vue';
+  import { nextTick, reactive, ref } from 'vue';
   import type { ISiteIIS, IPastaDeploy } from '@/models/SiteIISModel';
   import { PastaDeployModel } from '@/models/SiteIISModel';
+  import { notificar } from '@/utils/eventBus';
 
   const site = defineModel<ISiteIIS>({ required: true });
 
@@ -194,8 +195,11 @@
 
     if (index >= 0) {
       site.value.pastas[index] = { ...pastaEmEdicao };
+      notificar('sucesso', 'Pasta de deploy atualizada');
     } else {
       site.value.pastas.push({ ...pastaEmEdicao });
+      notificar('sucesso', 'Pasta de deploy cadastrada');
+      nextTick(() => formPasta.value.resetValidation());
     }
 
     descartarAlteracoes();
@@ -212,6 +216,7 @@
 
   const descartarAlteracoes = () => {
     Object.assign(pastaEmEdicao, new PastaDeployModel());
+    nextTick(() => formPasta.value?.resetValidation());
     exibirModalCadastroPasta.value = false;
   };
 </script>

--- a/frontend/src/components/sitesiis/PastasCadastro.vue
+++ b/frontend/src/components/sitesiis/PastasCadastro.vue
@@ -43,7 +43,10 @@
         :acaoBotaoSecundario="descartarAlteracoes"
         larguraMaxima="900px"
       >
-        <v-form ref="formPasta">
+        <v-form
+          ref="formPasta"
+          autocomplete="off"
+        >
           <v-row no-gutters>
             <v-col
               cols="12"
@@ -55,6 +58,7 @@
                 :rules="obrigatorio"
                 hint="Nome da pasta para backup (timestamp será adicionado)"
                 persistent-hint
+                autocomplete="off"
                 @blur="sugerirCaminhosComBaseNaPasta"
               />
             </v-col>
@@ -70,6 +74,7 @@
                 placeholder="C:\git\seu-projeto\frontend"
                 hint="Onde o comando de build será executado"
                 persistent-hint
+                autocomplete="off"
                 @blur="sugerirCaminhoOrigem"
               />
             </v-col>
@@ -85,6 +90,7 @@
                 placeholder="npm run build"
                 hint="Comando para fazer build/publish do projeto"
                 persistent-hint
+                autocomplete="off"
               />
             </v-col>
 
@@ -99,6 +105,7 @@
                 placeholder="C:\git\seu-projeto\frontend\dist"
                 hint="Pasta gerada após o build"
                 persistent-hint
+                autocomplete="off"
               />
             </v-col>
 
@@ -113,6 +120,7 @@
                 placeholder="C:\inetpub\wwwroot\seu-site\seu-micro-frontend"
                 hint="Destino no IIS"
                 persistent-hint
+                autocomplete="off"
               />
             </v-col>
           </v-row>

--- a/frontend/src/components/sitesiis/SiteIISCadastro.vue
+++ b/frontend/src/components/sitesiis/SiteIISCadastro.vue
@@ -1,5 +1,8 @@
 <template>
-  <v-form ref="formSite">
+  <v-form
+    ref="formSite"
+    autocomplete="off"
+  >
     <v-row no-gutters>
       <v-col
         cols="12"
@@ -11,6 +14,7 @@
           :rules="obrigatorio"
           hint="Nome que aparecerá no menu de Deploy"
           persistent-hint
+          autocomplete="off"
         />
       </v-col>
 
@@ -24,6 +28,7 @@
           :rules="obrigatorio"
           hint="Nome do site no IIS"
           persistent-hint
+          autocomplete="off"
           @blur="sugerirCaminhoPastaRaiz"
         />
       </v-col>
@@ -39,6 +44,7 @@
           placeholder="C:\inetpub\wwwroot\seu-site"
           hint="Diretório raiz do site no servidor"
           persistent-hint
+          autocomplete="off"
         />
       </v-col>
 

--- a/frontend/src/components/sitesiis/SiteIISCadastro.vue
+++ b/frontend/src/components/sitesiis/SiteIISCadastro.vue
@@ -57,12 +57,17 @@
 </template>
 
 <script setup lang="ts">
+  import { ref } from 'vue';
   import type { ISiteIIS } from '@/models/SiteIISModel';
   import SelectPerfilTerminal from '@/components/comum/SelectPerfilTerminal.vue';
 
   const site = defineModel<ISiteIIS>({ required: true });
 
+  const formSite = ref();
+
   const obrigatorio = [(v: any) => !!v || 'Campo obrigatório'];
+
+  defineExpose({ formSite });
 
   const sugerirCaminhoPastaRaiz = () => {
     if (site.value.nome && !site.value.pastaRaiz) {

--- a/frontend/src/views/IDEsView.vue
+++ b/frontend/src/views/IDEsView.vue
@@ -101,7 +101,7 @@
 </template>
 
 <script setup lang="ts">
-  import { onMounted, reactive, ref } from 'vue';
+  import { nextTick, onMounted, reactive, ref } from 'vue';
   import type { IIDE } from '@/types';
   import IDEModel from '@/models/IDEModel';
   import IDEsService from '@/services/IDEsService';
@@ -152,6 +152,10 @@
   const fecharModal = (): void => {
     modalAberto.value = false;
     ideSelecionada.value = new IDEModel();
+    nextTick(() => {
+      formRef.value?.resetValidation();
+      formRef.value?.reset();
+    });
   };
 
   const salvarIDE = async (): Promise<void> => {
@@ -171,10 +175,14 @@
       } else {
         await IDEsService.adicionarIDE(ideSelecionada.value);
         ides.push(new IDEModel(ideSelecionada.value));
-        notificar('sucesso', 'IDE criada');
+        notificar('sucesso', 'IDE cadastrada');
       }
 
       modalAberto.value = false;
+      nextTick(() => {
+        formRef.value.resetValidation();
+        formRef.value.reset();
+      });
     } catch (error: any) {
       console.error('Falha ao salvar IDE:', error);
       notificar('erro', error.response?.data || 'Falha ao salvar IDE');

--- a/frontend/src/views/IDEsView.vue
+++ b/frontend/src/views/IDEsView.vue
@@ -75,12 +75,16 @@
       :acaoBotaoPrimario="salvarIDE"
       :acaoBotaoSecundario="fecharModal"
     >
-      <v-form ref="formRef">
+      <v-form
+        ref="formRef"
+        autocomplete="off"
+      >
         <v-text-field
           v-model="ideSelecionada.nome"
           label="Nome da IDE"
           placeholder="Ex: VS Code, Kiro, Delphi"
           :rules="[regras.obrigatorio]"
+          autocomplete="off"
         />
 
         <v-text-field
@@ -88,6 +92,7 @@
           label="Comando para executar"
           placeholder="Ex: code ., kiro ."
           :rules="[regras.obrigatorio]"
+          autocomplete="off"
         />
 
         <v-checkbox

--- a/frontend/src/views/PastasView.vue
+++ b/frontend/src/views/PastasView.vue
@@ -3,38 +3,64 @@
     <div class="d-flex flex-column">
       <v-row no-gutters>
         <v-col
-          cols="9"
+          cols="8"
           class="pb-2"
         >
           <div
             class="d-flex align-center"
             style="gap: 16px"
           >
-            <h2 class="flex-shrink-0">
-              Pastas
-              <span
-                v-if="pastas.length > 0"
-                class="text-medium-emphasis text-body-1"
+            <template v-if="temCentralizadoras">
+              <v-tabs
+                v-model="abaSelecionada"
+                density="compact"
+                color="primary"
+                show-arrows
+                style="min-width: 0"
               >
-                ({{ pastas.length }})
-              </span>
-            </h2>
-
-            <v-tabs
-              v-model="abaSelecionada"
-              density="compact"
-              color="primary"
-              show-arrows
-              style="min-width: 0"
-            >
-              <v-tab
-                v-for="aba in abasDisponiveis"
-                :key="aba"
-                :value="aba"
+                <v-tab
+                  v-for="aba in abasDisponiveis"
+                  :key="aba"
+                  :value="aba"
+                >
+                  {{ aba }}
+                  <v-chip
+                    v-if="contagemPorAba[aba] > 0"
+                    size="x-small"
+                    class="ml-1"
+                    variant="tonal"
+                  >
+                    {{ contagemPorAba[aba] }}
+                  </v-chip>
+                </v-tab>
+              </v-tabs>
+            </template>
+            <template v-else>
+              <h2 class="flex-shrink-0">
+                Pastas
+                <span
+                  v-if="pastas.length > 0"
+                  class="text-medium-emphasis text-body-1"
+                >
+                  ({{ pastas.length }})
+                </span>
+              </h2>
+              <v-tabs
+                v-model="abaSelecionada"
+                density="compact"
+                color="primary"
+                show-arrows
+                style="min-width: 0"
               >
-                {{ aba }}
-              </v-tab>
-            </v-tabs>
+                <v-tab
+                  v-for="aba in abasDisponiveis"
+                  :key="aba"
+                  :value="aba"
+                >
+                  {{ aba }}
+                </v-tab>
+              </v-tabs>
+            </template>
 
             <v-spacer />
 
@@ -112,7 +138,7 @@
         class="flex-nowrap"
       >
         <v-col
-          cols="9"
+          cols="8"
           class="altura-limitada"
         >
           <div v-if="pastas.length === 0">
@@ -485,6 +511,19 @@
       return 0;
     });
     return ordenadas;
+  });
+
+  const temCentralizadoras = computed(
+    () => configuracaoStore.pastasCentralizadoras.length > 0
+  );
+
+  const contagemPorAba = computed(() => {
+    const contagem: Record<string, number> = {};
+    pastas.value.forEach(p => {
+      const aba = p.nomeAba || 'Raiz';
+      contagem[aba] = (contagem[aba] || 0) + 1;
+    });
+    return contagem;
   });
 
   const perfisDisponiveis = computed((): IPerfilMarcacao[] => {

--- a/frontend/src/views/RepositoriosView.vue
+++ b/frontend/src/views/RepositoriosView.vue
@@ -142,7 +142,10 @@
   const paginaPrincipal = ref<number>(0);
   const paginaCadastro = ref<number>(0);
   const camposObrigatoriosPreenchidos = ref<boolean>(true);
-  const repositorioCadastroRef = ref<{ focarUrl: () => void } | null>(null);
+  const repositorioCadastroRef = ref<{
+    focarUrl: () => void;
+    formRepositorio: { resetValidation: () => void };
+  } | null>(null);
 
   onMounted(async () => {
     await preencherRepositorios();
@@ -232,9 +235,12 @@
       );
       repositorios.push(new RepositorioModel(repositorioSelecionado.value));
       limparCampos();
-      notificar('sucesso', 'Repositorio criado');
+      notificar('sucesso', 'Repositório cadastrado');
       irParaCadastro();
-      nextTick(() => repositorioCadastroRef.value?.focarUrl());
+      nextTick(() => {
+        repositorioCadastroRef.value?.formRepositorio.resetValidation();
+        repositorioCadastroRef.value?.focarUrl();
+      });
     } catch (error) {
       console.error('Falha ao criar repositorio: ' + error);
       notificar('erro', 'Falha ao criar repositorio');
@@ -255,7 +261,7 @@
         Object.assign(repositorios[indice], repositorioSelecionado.value);
 
       limparCampos();
-      notificar('sucesso', 'Repositorio atualizado');
+      notificar('sucesso', 'Repositório atualizado');
       irParaListagem();
     } catch (error) {
       console.error('Falha ao criar repositorio' + error);

--- a/frontend/src/views/SitesIISView.vue
+++ b/frontend/src/views/SitesIISView.vue
@@ -45,6 +45,7 @@
               <v-tabs-window v-model="paginaCadastro">
                 <v-tabs-window-item>
                   <SiteIISCadastro
+                    ref="siteCadastroRef"
                     v-model="siteSelecionado"
                     class="pt-4"
                   />
@@ -88,7 +89,7 @@
 </template>
 
 <script setup lang="ts">
-  import { computed, onMounted, reactive, ref } from 'vue';
+  import { computed, nextTick, onMounted, reactive, ref } from 'vue';
   import type { ISiteIIS, ISiteIISDeployResponse } from '@/models/SiteIISModel';
   import ListaSitesIIS from '@/components/sitesiis/ListaSitesIIS.vue';
   import SiteIISCadastro from '@/components/sitesiis/SiteIISCadastro.vue';
@@ -104,6 +105,9 @@
   const siteSelecionado = ref<ISiteIIS>(new SiteIISModel());
   const paginaPrincipal = ref<number>(0);
   const paginaCadastro = ref<number>(0);
+  const siteCadastroRef = ref<InstanceType<typeof SiteIISCadastro> | null>(
+    null
+  );
 
   onMounted(async () => {
     await preencherSites();
@@ -214,7 +218,8 @@
       await store.adicionarSite(siteSelecionado.value);
       await preencherSites();
       limparCampos();
-      notificar('sucesso', 'Site criado');
+      notificar('sucesso', 'Site cadastrado');
+      nextTick(() => siteCadastroRef.value?.formSite.resetValidation());
       irParaListagem();
 
       // Recarregar lista do dropdown de deploy


### PR DESCRIPTION
## O que mudou

### Formulários de cadastro
- Notificações padronizadas: agora exibem **"Entidade cadastrada"** (novo) / **"Entidade atualizada"** (edição) em todos os cadastros (Repositório, Projeto, Menu, Perfil, IDE, Site, Pasta, etc.)
- Reset da validação do formulário após salvar: `resetValidation()` movido para dentro de `nextTick()` para garantir que os campos limpos não fiquem com erro vermelho

### Autocomplete
- Adicionado `autocomplete="off"` em todos os `v-form` e `v-text-field` de cadastro para evitar sugestões do navegador

### Correção de bugs

### Ignorar no git diff ao aplicar arquivo (`backend/src/Services/ComandoService.cs`)
- **Problema:** `git update-index --assume-unchanged` falhava na primeira execução porque:
  1. O caminho passado era apenas o nome do arquivo, mas o git espera o caminho relativo à **raiz do repositório**
  2. Arquivos recém-copiados não estão no índice git, então o comando não tinha efeito
- **Correção:** A função `IgnorarArquivoNoGit` agora:
  1. Descobre a raiz do repositório com `git rev-parse --show-toplevel`
  2. Calcula o caminho relativo correto com `Path.GetRelativePath`
  3. Se o arquivo está rastreado: executa `git update-index --assume-unchanged` com o caminho relativo correto
  4. Se não está rastreado: adiciona a entrada ao `.gitignore`

## Como testar
1. Abrir um repositório com cadastro de Menu de Contexto > Aplicar Arquivo
2. Marcar "Ignorar no git diff" e salvar
3. Executar o menu — o arquivo deve ser ignorado de primeira (sem precisar executar duas vezes)
4. Testar cadastro de qualquer entidade — deve resetar a validação ao salvar e continuar cadastrando
5. Verificar que campos de formulário não mostram sugestão de autocomplete do navegador