### PR TITLE
fix(versao): corrige leitura da versão atual do assembly

### DIFF
--- a/backend/src/Services/VersaoService.cs
+++ b/backend/src/Services/VersaoService.cs
@@ -73,9 +73,11 @@ public class VersaoService(HttpClient httpClient)
 
     private static string ObterVersaoAtual()
     {
-        var version = Assembly.GetExecutingAssembly().GetName().Version;
-        if (version is null) return "0.0.0";
-        return $"{version.Major}.{version.Minor}.{version.Build}";
+        var assembly = Assembly.GetExecutingAssembly();
+        var infoVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        if (infoVersion is not null) return infoVersion;
+        var version = assembly.GetName().Version;
+        return version is null ? "0.0.0" : $"{version.Major}.{version.Minor}.{version.Build}";
     }
 
     private static int CompararVersao(string a, string b)


### PR DESCRIPTION
## O que mudou

### `backend/src/Services/VersaoService.cs`
Corrige o método `ObterVersaoAtual()` que usava `Assembly.GetName().Version` (retorna `AssemblyVersion` = `1.0.0.0` por default no .NET SDK), fazendo a versão lida ser sempre `1.0.0` independente do `<Version>` no `.csproj$.

A correção muda para ler `AssemblyInformationalVersionAttribute`, que reflete exatamente o valor de `<Version>` definido no `.csproj`.

### Correções de bugs
- Versão atual do app agora é lida corretamente (ex: `1.0.5` ao invés de `1.0.0`)
- Comparação com a versão do GitHub agora funciona corretamente: se a versão atual é `1.0.5` e a última release também é `1.0.5$, não mostra falsa atualização disponível

## Como testar
1. `cd backend && dotnet build`
2. `dotnet run` e acessar `GET /api/versao`
3. Verificar que `versaoAtual` retorna `1.0.5` (ou a versão atual do .csproj), não `1.0.0`
4. Clicar em "Verificar atualizações" na UI e confirmar que mostra "Você está na versão mais recente" quando não há release mais nova