### PR TITLE
feat(terminals): manter terminal no diretório do projeto após Ctrl+C

### DIFF
--- a/backend/src/Utils/LinuxShellProvider.cs
+++ b/backend/src/Utils/LinuxShellProvider.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Text.RegularExpressions;
 using ProjectManagerWeb.src.Services;
 using ProjectManagerWeb.src.Utils.Terminais;
 
@@ -87,7 +88,8 @@ public class LinuxShellProvider(ConfiguracaoService configuracaoService) : IShel
 
     public void ExecutarComInterface(string command, string? perfilTerminal = null)
     {
-        Terminal.Executar(GarantirPathUsuario(command), perfilTerminal);
+        var workingDirectory = ExtrairDiretorioDoComando(command);
+        Terminal.Executar(GarantirPathUsuario(command), perfilTerminal, workingDirectory);
     }
 
     public void ExecutarSemInterface(string command)
@@ -122,4 +124,10 @@ public class LinuxShellProvider(ConfiguracaoService configuracaoService) : IShel
 
     private static string EscapeBash(string command) =>
         command.Replace("\"", "\\\"");
+
+    private static string? ExtrairDiretorioDoComando(string command)
+    {
+        var match = Regex.Match(command, @"cd\s+""([^""]+)""");
+        return match.Success ? match.Groups[1].Value : null;
+    }
 }

--- a/backend/src/Utils/Terminais/GhosttyTerminal.cs
+++ b/backend/src/Utils/Terminais/GhosttyTerminal.cs
@@ -4,14 +4,17 @@ namespace ProjectManagerWeb.src.Utils.Terminais;
 
 public class GhosttyTerminal : ITerminalEmulator
 {
-    public void Executar(string command, string? perfilTerminal = null)
+    public void Executar(string command, string? perfilTerminal = null, string? workingDirectory = null)
     {
         var trimmed = command.TrimEnd(' ', ';');
+        var execBash = !string.IsNullOrWhiteSpace(workingDirectory)
+            ? $"cd \"{EscapeBash(workingDirectory)}\" && exec bash"
+            : "exec bash";
 
         Process.Start(new ProcessStartInfo
         {
             FileName = "ghostty",
-            Arguments = $"-e bash -l -i -c \"trap '' INT; (trap - INT; {EscapeBash(trimmed)}); exec bash\"",
+            Arguments = $"-e bash -l -i -c \"trap '' INT; (trap - INT; {EscapeBash(trimmed)}); {execBash}\"",
             UseShellExecute = false
         });
     }

--- a/backend/src/Utils/Terminais/ITerminalEmulator.cs
+++ b/backend/src/Utils/Terminais/ITerminalEmulator.cs
@@ -2,6 +2,6 @@ namespace ProjectManagerWeb.src.Utils.Terminais;
 
 public interface ITerminalEmulator
 {
-    void Executar(string command, string? perfilTerminal = null);
+    void Executar(string command, string? perfilTerminal = null, string? workingDirectory = null);
     List<string> ObterPerfis();
 }

--- a/backend/src/Utils/Terminais/PtyxisTerminal.cs
+++ b/backend/src/Utils/Terminais/PtyxisTerminal.cs
@@ -4,19 +4,22 @@ namespace ProjectManagerWeb.src.Utils.Terminais;
 
 public class PtyxisTerminal : ITerminalEmulator
 {
-    public void Executar(string command, string? perfilTerminal = null)
+    public void Executar(string command, string? perfilTerminal = null, string? workingDirectory = null)
     {
         var trimmed = command.TrimEnd(' ', ';');
+        var execBash = !string.IsNullOrWhiteSpace(workingDirectory)
+            ? $"cd \"{EscapeBash(workingDirectory)}\" && exec bash"
+            : "exec bash";
         string args;
 
         if (!string.IsNullOrWhiteSpace(perfilTerminal))
         {
             var uuid = ResolverUuidPerfil(perfilTerminal);
-            args = $"--tab-with-profile=\"{uuid}\" -- bash -l -i -c \"trap '' INT; (trap - INT; {EscapeBash(trimmed)}); exec bash\"";
+            args = $"--tab-with-profile=\"{uuid}\" -- bash -l -i -c \"trap '' INT; (trap - INT; {EscapeBash(trimmed)}); {execBash}\"";
         }
         else
         {
-            args = $"--tab -- bash -l -i -c \"trap '' INT; (trap - INT; {EscapeBash(trimmed)}); exec bash\"";
+            args = $"--tab -- bash -l -i -c \"trap '' INT; (trap - INT; {EscapeBash(trimmed)}); {execBash}\"";
         }
 
         Process.Start(new ProcessStartInfo


### PR DESCRIPTION
## O que mudou

### `backend/src/Utils/LinuxShellProvider.cs`, `backend/src/Utils/Terminais/PtyxisTerminal.cs`, `backend/src/Utils/Terminais/GhosttyTerminal.cs`, `backend/src/Utils/Terminais/ITerminalEmulator.cs`
Quando o PMW abre um terminal no Linux para executar comandos como `npm start` ou `dotnet run`, ao apertar **Ctrl+C** o terminal agora permanece no **diretório do projeto** (frontend/backend) ao invés de voltar para `/opt/pmw` ou `$HOME`.

### Correções de bugs
- **Terminal voltava ao diretório padrão após Ctrl+C**: o `exec bash` final iniciava um novo shell sempre no `$HOME`. Agora extraímos o diretório do primeiro `cd "..."` do comando e fazemos `cd "<dir>" && exec bash`, mantendo o terminal no diretório do projeto.

## Como testar
1. No frontend do PMW, clique em **Iniciar** em um projeto (frontend ou backend)
2. O terminal abre com o comando rodando
3. Aperte **Ctrl+C** para parar o processo
4. **Antes**: terminal ficava em `/opt/pmw` ou `$HOME`
5. **Agora**: terminal permanece no diretório do projeto (ex: `/caminho/para/o/projeto`)
6. Windows continua funcionando normalmente (não precisou de alteração)