### PR TITLE
feat: testes unitarios, cobertura, CI/CD, correcoes de terminal e marcacoes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,3 +70,53 @@ jobs:
         run: |
           dotnet restore
           dotnet build --no-restore --nologo
+
+  test-backend:
+    runs-on: ubuntu-latest
+    needs: build-backend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.x'
+
+      - name: Install ReportGenerator
+        run: dotnet tool install -g dotnet-reportgenerator-globaltool
+
+      - name: Run tests with coverage
+        working-directory: backend
+        run: dotnet test tests/ProjectManagerWeb.Tests/ProjectManagerWeb.Tests.csproj
+          --collect:"XPlat Code Coverage"
+          --settings Coverage.runsettings
+          --results-directory tests/CoverageResults
+          --nologo
+          --verbosity minimal
+
+      - name: Generate coverage report
+        working-directory: backend
+        run: reportgenerator
+          -reports:"tests/CoverageResults/**/coverage.cobertura.xml"
+          -targetdir:"tests/CoverageReport"
+          -reporttypes:Html
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: backend/tests/CoverageReport
+          retention-days: 7
+
+      - name: Show coverage summary
+        working-directory: backend
+        run: |
+          COVERAGE_FILE=$(find tests/CoverageResults -name "coverage.cobertura.xml" -print -quit)
+          if [ -n "$COVERAGE_FILE" ]; then
+            COVERAGE=$(grep -oP 'line-rate="\K[0-9.]+' "$COVERAGE_FILE" | head -1)
+            if [ -n "$COVERAGE" ]; then
+              PERCENT=$(echo "$COVERAGE * 100" | bc -l | xargs printf "%.1f")
+              echo "### Cobertura de linha: $PERCENT%" >> $GITHUB_STEP_SUMMARY
+            fi
+          fi

--- a/.opencode/agents/fullstack-dev.md
+++ b/.opencode/agents/fullstack-dev.md
@@ -10,6 +10,7 @@ permission:
     "*": deny
     backend: allow
     frontend: allow
+    testador: allow
 color: "#00d4aa"
 ---
 

--- a/.opencode/agents/fullstack-dev.md
+++ b/.opencode/agents/fullstack-dev.md
@@ -44,6 +44,6 @@ Você é um desenvolvedor fullstack sênior com 15 anos de experiência no PMW.
 ## Proibições
 
 - NUNCA hardcodar secrets, API keys ou connection strings
-- NUNCA git commit/push/pull/merge/rebase — responsabilidade do usuário
+- **NUNCA git add, commit, push, pull, merge, rebase — NUNCA.** Responsabilidade exclusiva do usuário. O usuário revisa e commita pessoalmente. O skill `criar-mr` tem permissão total.
 - NUNCA inventar informação — investigue antes
 - NUNCA pular camadas: Component → Store → Service → API | Controller → Service → JsonService

--- a/.opencode/agents/testador.md
+++ b/.opencode/agents/testador.md
@@ -1,0 +1,142 @@
+---
+description: Especialista em testes unitários e de integração .NET 9 + xUnit. Escreve, refatora e mantém a suíte de testes do PMW. Segue o code-style do projeto. Sempre em português.
+mode: subagent
+model: deepseek/deepseek-v4-flash
+permission:
+  task:
+    "*": deny
+    backend: allow
+color: "#ff6b6b"
+---
+
+Você é um engenheiro de qualidade sênior especializado em testes .NET. 15 anos de experiência em TDD, testes unitários e de integração.
+
+## Stack de teste do PMW
+
+- **Framework:** xUnit
+- **Mocking:** NSubstitute
+- **Assertions:** FluentAssertions
+- **Cobertura:** Coverlet + ReportGenerator
+- **Dados fake:** Bogus (opcional)
+
+## Comportamento
+
+- Tudo em português: resposta, código, nomes de método, variáveis.
+- Seja direto. Sem enrolação.
+- Teste o comportamento, não a implementação.
+- Um assert por teste (ou asserts semanticamente relacionados).
+- Siga o code-style do projeto em TODOS os arquivos de teste também.
+- Zero comentários nos testes — nomes auto-documentados.
+
+## Estrutura de testes
+
+```
+backend/tests/ProjectManagerWeb.Tests/
+├── ProjectManagerWeb.Tests.csproj
+├── Services/
+│   ├── CloneServiceTests.cs
+│   ├── ComandoServiceTests.cs
+│   └── ...
+├── Controllers/
+│   └── ...
+└── Utils/
+    └── ...
+```
+
+## Nomenclatura de testes
+
+```
+Deve_acao_quando_cenario_de_negocio
+Nao_deve_acao_quando_cenario_de_negocio
+
+Ex: Deve_retornar_true_quando_branch_existe
+Ex: Deve_retornar_false_com_mensagem_padrao_quando_git_falha_sem_mensagem
+Ex: Nao_deve_usar_filter_quando_historico_completo
+Ex: Deve_retornar_vazio_quando_git_falha_ao_consultar
+```
+
+**Regra de ouro:** descreva o cenário de negócio, não detalhe técnico interno (variável, exit code, campo).
+- ✅ `quando_branch_nao_existe` — cenário que qualquer pessoa entende
+- ❌ `quando_exit_code_nao_zero_com_stderr` — detalhe de implementação que não comunica nada
+
+## Agrupamento (describe/it)
+
+Use **classes aninhadas** (nested classes) para agrupar testes por método. A classe externa contém o setup compartilhado. Cada classe interna é um grupo (describe) e cada método de teste é um caso (it).
+
+```csharp
+public class CloneServiceTests
+{
+    private readonly IGitCommandRunner _gitRunner = Substitute.For<IGitCommandRunner>();
+    private readonly CloneService _sut;
+
+    public CloneServiceTests()
+    {
+        _sut = new CloneService(Substitute.For<RepositorioJsonService>(), _gitRunner);
+    }
+
+    public class VerificarBranchExisteAsync : CloneServiceTests
+    {
+        [Fact]
+        public async Task Deve_retornar_true_quando_output_contem_hash()
+        {
+            _gitRunner.RunAsync(Arg.Any<string>(), Arg.Any<string>())
+                .Returns(new ComandoResultado("abc123\thead", string.Empty, 0));
+
+            var (existe, _) = await _sut.VerificarBranchExisteAsync("url", "branch");
+
+            existe.Should().BeTrue();
+        }
+    }
+}
+```
+
+## Testes parametrizados (Theory com InlineData)
+
+Quando um método tem apenas parâmetros distintos, use `[Theory]` com `[InlineData]`. O nome do teste descreve a regra geral, e cada `InlineData` vira um caso de teste.
+
+```csharp
+public class EhBranchBase : CloneServiceTests
+{
+    [Theory]
+    [InlineData("main", true)]
+    [InlineData("master", true)]
+    [InlineData("feature/nova", false)]
+    [InlineData("fix/bug", false)]
+    public void Deve_retornar_true_apenas_para_branches_base(string branch, bool esperado)
+    {
+        CloneService.EhBranchBase(branch).Should().Be(esperado);
+    }
+}
+```
+
+## Proibições
+
+- Sem comentários nos testes — nomes auto-documentados.
+- If de uma linha **SEM** chaves.
+- Evitar if/else — ternário pra 2 caminhos.
+- Sem `Console.WriteLine` nos testes — usar `ITestOutputHelper` se precisar de log.
+- Testes NUNCA chamam `Process.Start` real — sempre mockado.
+- Testes NUNCA acessam disco real — sempre mockado.
+- Sem testes frágeis (dependentes de ordem, horário, ambiente).
+
+## O que testar
+
+| Situação | Sim/Não |
+|----------|---------|
+| Lógica de negócio pura (regras, validações) | ✅ Sempre |
+| Parsing de output de comandos | ✅ Sempre |
+| Montagem de scripts/comandos | ✅ Sempre |
+| Tratamento de erro e exceções | ✅ Sempre |
+| Ramificações (todos os caminhos if/else) | ✅ Sempre |
+| `Process.Start` real | ❌ Nunca |
+| Serialização JSON | ❌ Não (é do framework) |
+| DI / configuração | ❌ Não |
+
+## Workflow
+
+1. **LER** — Leia a classe a ser testada e suas dependências.
+2. **IDENTIFICAR** — Liste os métodos puros (testáveis sem mock) vs métodos com dependências externas.
+3. **REFATORAR** — Se necessário, extraia interfaces para dependências estáticas (`Process.Start`, `ShellExecute`).
+4. **TESTAR** — Escreva os testes seguindo o padrão AAA e a nomenclatura `Deve/NaoDeve`.
+5. **EXECUTAR** — Rode `dotnet test` e corrija falhas.
+6. **COBERTURA** — Rode cobertura e garanta >80% na classe testada.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ dotnet publish            # publicar para IIS
   ❌ `if (!item) { return; }`
 - **Evite if/else** — use ternário pra 2 caminhos ou objetos mapeados para múltiplos.
 - NUNCA hardcodar secrets, API keys ou connection strings
-- NUNCA git commit/push/pull/merge/rebase — responsabilidade do usuário
+- **NUNCA git add, commit, push, pull, merge, rebase — NUNCA.** Responsabilidade exclusiva do usuário. O usuário revisa e commita pessoalmente. O skill `criar-mr` tem permissão total.
 - NUNCA inventar informação — investigue antes
 
 ## Git

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,16 @@ dotnet publish            # publicar para IIS
 
 # Tudo junto (raiz)
 .\Atualizar_PMW.ps1      # atualizar do último release
+
+# Testes
+dotnet test backend/tests/ProjectManagerWeb.Tests/ProjectManagerWeb.Tests.csproj  # rodar testes
+bash backend/test-coverage.sh  # testes + relatório de cobertura HTML
+```
+
+Para relatório de cobertura, instalar o ReportGenerator antes:
+```bash
+dotnet tool install -g dotnet-reportgenerator-globaltool
+```
 ```
 
 ## Proibições (valem pra todo o repositório)

--- a/backend/Coverage.runsettings
+++ b/backend/Coverage.runsettings
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat Code Coverage">
+        <Configuration>
+          <Format>cobertura</Format>
+          <ExcludeByFile>**/Program.cs,**/Controllers/*.cs,**/DTOs/*.cs,**/IISService.cs,**/DeployIISService.cs,**/MigrationService.cs,**/PastaService.cs,**/InformacaoService.cs,**/TerminalService.cs,**/PathHelper.cs,**/ShellExecute.cs,**/ShellExecutor.cs,**/IShell*.cs,**/WindowsShellProvider.cs,**/Terminais/ITerminalEmulator.cs,**/Terminais/PtyxisTerminal.cs,**/Terminais/GhosttyTerminal.cs,**/IIDEJsonService.cs,**/IGitCommandRunner.cs</ExcludeByFile>
+          <IncludeTestAssembly>false</IncludeTestAssembly>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -25,6 +25,7 @@ builder.Services.AddControllers().AddJsonOptions(options =>
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSingleton<RepositorioJsonService>();
 builder.Services.AddSingleton<ConfiguracaoService>();
+builder.Services.AddSingleton<IGitCommandRunner, GitCommandRunner>();
 builder.Services.AddSingleton<CloneService>();
 builder.Services.AddSingleton<PastaService>();
 builder.Services.AddSingleton<ComandoService>();

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -25,6 +25,7 @@ builder.Services.AddControllers().AddJsonOptions(options =>
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSingleton<RepositorioJsonService>();
 builder.Services.AddSingleton<ConfiguracaoService>();
+builder.Services.AddSingleton<IShellExecutor, ShellExecutor>();
 builder.Services.AddSingleton<IGitCommandRunner, GitCommandRunner>();
 builder.Services.AddSingleton<CloneService>();
 builder.Services.AddSingleton<PastaService>();
@@ -34,6 +35,7 @@ builder.Services.AddSingleton<IISService>();
 builder.Services.AddSingleton<SiteIISJsonService>();
 builder.Services.AddSingleton<DeployIISService>();
 builder.Services.AddSingleton<IDEJsonService>();
+builder.Services.AddSingleton<IIDEJsonService>(sp => sp.GetRequiredService<IDEJsonService>());
 builder.Services.AddSingleton<MigrationService>();
 builder.Services.AddSingleton<TerminalService>();
 builder.Services.AddHttpClient<VersaoService>();

--- a/backend/ProjectManagerWeb.csproj
+++ b/backend/ProjectManagerWeb.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <Version>1.0.8</Version>
+    <DefaultItemExcludes>$(DefaultItemExcludes);tests/**</DefaultItemExcludes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/backend/ProjectManagerWeb.csproj
+++ b/backend/ProjectManagerWeb.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <Version>1.0.6</Version>
+    <DefaultItemExcludes>$(DefaultItemExcludes);tests/**</DefaultItemExcludes>
   </PropertyGroup>
 
   <ItemGroup>
@@ -22,7 +23,10 @@
 <PropertyGroup>
   <ApplicationIcon>logo.ico</ApplicationIcon>
   <UseWinForms>true</UseWinForms>
-  <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 </PropertyGroup>
+
+<ItemGroup>
+  <InternalsVisibleTo Include="ProjectManagerWeb.Tests" />
+</ItemGroup>
 
 </Project>

--- a/backend/src/Services/CloneService.cs
+++ b/backend/src/Services/CloneService.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Text;
 using ProjectManagerWeb.src.DTOs;
 using ProjectManagerWeb.src.Utils;
@@ -8,18 +7,20 @@ namespace ProjectManagerWeb.src.Services;
 public class CloneService
 {
     private readonly RepositorioJsonService _repositorioJson;
+    private readonly IGitCommandRunner _gitRunner;
 
-    public CloneService(RepositorioJsonService repositorioJson)
+    public CloneService(RepositorioJsonService repositorioJson, IGitCommandRunner gitRunner)
     {
         if (!Directory.Exists(PathHelper.BancoPath))
             Directory.CreateDirectory(PathHelper.BancoPath);
 
         _repositorioJson = repositorioJson;
+        _gitRunner = gitRunner;
     }
 
     public async Task<(bool Existe, string? Erro)> VerificarBranchExisteAsync(string url, string branch, string? caminhoChaveSSH = null)
     {
-        var resultado = await ExecutarComandoComRetornoAsync($"git ls-remote --heads \"{url}\" \"{branch}\"", caminhoChaveSSH);
+        var resultado = await _gitRunner.RunAsync($"git ls-remote --heads \"{url}\" \"{branch}\"", caminhoChaveSSH);
 
         if (resultado.ExitCode != 0)
         {
@@ -34,7 +35,7 @@ public class CloneService
 
     public async Task<string> DetectarBranchPrincipalAsync(string url, string? caminhoChaveSSH = null)
     {
-        var resultado = await ExecutarComandoComRetornoAsync($"git ls-remote --symref \"{url}\" HEAD", caminhoChaveSSH);
+        var resultado = await _gitRunner.RunAsync($"git ls-remote --symref \"{url}\" HEAD", caminhoChaveSSH);
 
         if (resultado.ExitCode != 0) return string.Empty;
 
@@ -135,7 +136,7 @@ public class CloneService
         return true;
     }
 
-    private static string MontarScript(string diretorioCompleto, string url, string nomeRepo, CloneRequestDTO clone, string branchPrincipal = "")
+    internal static string MontarScript(string diretorioCompleto, string url, string nomeRepo, CloneRequestDTO clone, string branchPrincipal = "")
     {
         // branch não-base: clona a principal, depois faz fetch da branch informada
         // branch base: clona direto com --branch, sem baixar outras refs
@@ -167,55 +168,6 @@ public class CloneService
         return script.ToString();
     }
 
-    private static bool EhBranchBase(string branch) =>
+    internal static bool EhBranchBase(string branch) =>
         branch is "develop" or "dev" or "main" or "master";
-
-    private static async Task<ComandoResultado> ExecutarComandoComRetornoAsync(string comando, string? caminhoChaveSSH = null)
-    {
-        var useShell = OperatingSystem.IsWindows();
-
-        var psi = new ProcessStartInfo
-        {
-            FileName = useShell ? "git" : "bash",
-            Arguments = useShell ? comando["git ".Length..] : $"-c \"{comando.Replace("\"", "\\\"")}\"",
-            UseShellExecute = false,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            CreateNoWindow = true
-        };
-
-        if (!string.IsNullOrEmpty(caminhoChaveSSH))
-            psi.EnvironmentVariables["GIT_SSH_COMMAND"] = $"ssh -i \"{caminhoChaveSSH}\"";
-
-        if (!useShell)
-        {
-            var sshSock = Environment.GetEnvironmentVariable("SSH_AUTH_SOCK");
-            if (!string.IsNullOrEmpty(sshSock))
-                psi.EnvironmentVariables["SSH_AUTH_SOCK"] = sshSock;
-
-            var sshPid = Environment.GetEnvironmentVariable("SSH_AGENT_PID");
-            if (!string.IsNullOrEmpty(sshPid))
-                psi.EnvironmentVariables["SSH_AGENT_PID"] = sshPid;
-        }
-
-        using var processo = Process.Start(psi);
-        if (processo is null) return new ComandoResultado(string.Empty, "Processo não iniciado", -1);
-
-        var output = await processo.StandardOutput.ReadToEndAsync();
-        var error = await processo.StandardError.ReadToEndAsync();
-        await processo.WaitForExitAsync();
-
-        return new ComandoResultado(output, FiltrarWarnings(error), processo.ExitCode);
-    }
-
-    private static string FiltrarWarnings(string stderr)
-    {
-        if (string.IsNullOrWhiteSpace(stderr)) return string.Empty;
-
-        var linhas = stderr.Split('\n', StringSplitOptions.RemoveEmptyEntries);
-        var semWarnings = linhas.Where(l => !l.StartsWith("Environment variable $"));
-        return string.Join('\n', semWarnings);
-    }
-
-    private sealed record ComandoResultado(string Output, string Error, int ExitCode);
 }

--- a/backend/src/Services/ComandoService.cs
+++ b/backend/src/Services/ComandoService.cs
@@ -5,7 +5,7 @@ using ProjectManagerWeb.src.Enuns;
 
 namespace ProjectManagerWeb.src.Services;
 
-public class ComandoService(RepositorioJsonService repositorioJsonService, IDEJsonService ideJsonService)
+public class ComandoService(RepositorioJsonService repositorioJsonService, IIDEJsonService ideJsonService, IShellExecutor shellExecutor)
 {
     public async Task<bool> ExecutarComando(PastaRequestDTO pasta)
     {
@@ -114,7 +114,7 @@ public class ComandoService(RepositorioJsonService repositorioJsonService, IDEJs
 
         try
         {
-            comandos.ForEach(c => ShellExecute.ExecutarComando(c.Comando, c.Perfil, repositorio.GitHubToken));
+            comandos.ForEach(c => shellExecutor.ExecutarComando(c.Comando, c.Perfil, repositorio.GitHubToken));
         }
         catch
         {
@@ -132,7 +132,7 @@ public class ComandoService(RepositorioJsonService repositorioJsonService, IDEJs
     {
         try
         {
-            ShellExecute.ExecutarComando(comando, perfilTerminal, githubToken);
+            shellExecutor.ExecutarComando(comando, perfilTerminal, githubToken);
         }
         catch
         {
@@ -200,7 +200,7 @@ public class ComandoService(RepositorioJsonService repositorioJsonService, IDEJs
         {
             try
             {
-                ShellExecute.ExecutarComando(c, githubToken: repositorio.GitHubToken);
+                shellExecutor.ExecutarComando(c, githubToken: repositorio.GitHubToken);
                 ShellExecute.LogComando(c, "OK");
             }
             catch (Exception ex)
@@ -306,7 +306,7 @@ public class ComandoService(RepositorioJsonService repositorioJsonService, IDEJs
 
         try
         {
-            ShellExecute.ExecutarComandoSemInterface(comando);
+            shellExecutor.ExecutarComandoSemInterface(comando);
         }
         catch
         {
@@ -316,7 +316,7 @@ public class ComandoService(RepositorioJsonService repositorioJsonService, IDEJs
         return true;
     }
 
-    private static string ObterAlvoIDE(string diretorio, bool abrirWorkspace)
+    internal static string ObterAlvoIDE(string diretorio, bool abrirWorkspace)
     {
         if (abrirWorkspace && Directory.Exists(diretorio))
         {

--- a/backend/src/Services/ConfiguracaoService.cs
+++ b/backend/src/Services/ConfiguracaoService.cs
@@ -7,11 +7,9 @@ namespace ProjectManagerWeb.src.Services;
 public class ConfiguracaoService
 {
     private static readonly string BasePath = PathHelper.BancoPath;
-
-    private static readonly string FilePath =
-        Path.Combine(BasePath, "Configuracao.json");
-
     private static readonly SemaphoreSlim _semaphore = new(1, 1);
+
+    private readonly string _filePath;
 
     private readonly JsonSerializerOptions _jsonOptions = new()
     {
@@ -21,10 +19,15 @@ public class ConfiguracaoService
 
     public ConfiguracaoService()
     {
+        _filePath = Path.Combine(BasePath, "Configuracao.json");
+
         if (!Directory.Exists(BasePath))
-        {
             Directory.CreateDirectory(BasePath);
-        }
+    }
+
+    internal ConfiguracaoService(string test_filePath) : this()
+    {
+        _filePath = test_filePath;
     }
 
     /// <summary>
@@ -35,12 +38,12 @@ public class ConfiguracaoService
         await _semaphore.WaitAsync();
         try
         {
-            if (!File.Exists(FilePath))
+            if (!File.Exists(_filePath))
             {
                 return new ConfiguracaoRequestDTO();
             }
 
-            var jsonString = await File.ReadAllTextAsync(FilePath);
+            var jsonString = await File.ReadAllTextAsync(_filePath);
             if (string.IsNullOrWhiteSpace(jsonString))
             {
                 return new ConfiguracaoRequestDTO();
@@ -64,7 +67,7 @@ public class ConfiguracaoService
         try
         {
             var jsonString = JsonSerializer.Serialize(configuracao, _jsonOptions);
-            await File.WriteAllTextAsync(FilePath, jsonString);
+            await File.WriteAllTextAsync(_filePath, jsonString);
         }
         finally
         {

--- a/backend/src/Services/GitCommandRunner.cs
+++ b/backend/src/Services/GitCommandRunner.cs
@@ -1,0 +1,53 @@
+using System.Diagnostics;
+
+namespace ProjectManagerWeb.src.Services;
+
+public class GitCommandRunner : IGitCommandRunner
+{
+    public async Task<ComandoResultado> RunAsync(string command, string? sshKey = null)
+    {
+        var useShell = OperatingSystem.IsWindows();
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = useShell ? "git" : "bash",
+            Arguments = useShell ? command["git ".Length..] : $"-c \"{command.Replace("\"", "\\\"")}\"",
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+
+        if (!string.IsNullOrEmpty(sshKey))
+            psi.EnvironmentVariables["GIT_SSH_COMMAND"] = $"ssh -i \"{sshKey}\"";
+
+        if (!useShell)
+        {
+            var sshSock = Environment.GetEnvironmentVariable("SSH_AUTH_SOCK");
+            if (!string.IsNullOrEmpty(sshSock))
+                psi.EnvironmentVariables["SSH_AUTH_SOCK"] = sshSock;
+
+            var sshPid = Environment.GetEnvironmentVariable("SSH_AGENT_PID");
+            if (!string.IsNullOrEmpty(sshPid))
+                psi.EnvironmentVariables["SSH_AGENT_PID"] = sshPid;
+        }
+
+        using var processo = Process.Start(psi);
+        if (processo is null) return new ComandoResultado(string.Empty, "Processo não iniciado", -1);
+
+        var output = await processo.StandardOutput.ReadToEndAsync();
+        var error = await processo.StandardError.ReadToEndAsync();
+        await processo.WaitForExitAsync();
+
+        return new ComandoResultado(output, FiltrarWarnings(error), processo.ExitCode);
+    }
+
+    internal static string FiltrarWarnings(string stderr)
+    {
+        if (string.IsNullOrWhiteSpace(stderr)) return string.Empty;
+
+        var linhas = stderr.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        var semWarnings = linhas.Where(l => !l.StartsWith("Environment variable $"));
+        return string.Join('\n', semWarnings);
+    }
+}

--- a/backend/src/Services/IDEJsonService.cs
+++ b/backend/src/Services/IDEJsonService.cs
@@ -8,18 +8,23 @@ namespace ProjectManagerWeb.src.Services
     {
         private static readonly string BasePath = PathHelper.BancoPath;
 
-        private static readonly string FilePath =
-            Path.Combine(BasePath, "IDEs.json");
-
         private static readonly SemaphoreSlim _semaphore = new(1, 1);
         private readonly JsonSerializerOptions _jsonOptions = new() { WriteIndented = true };
+        private readonly string _filePath;
 
         public IDEJsonService()
         {
+            _filePath = Path.Combine(BasePath, "IDEs.json");
+
             if (!Directory.Exists(BasePath))
             {
                 Directory.CreateDirectory(BasePath);
             }
+        }
+
+        internal IDEJsonService(string testFilePath) : this()
+        {
+            _filePath = testFilePath;
         }
 
         // --- MÉTODOS PÚBLICOS DO CRUD ---
@@ -114,14 +119,14 @@ namespace ProjectManagerWeb.src.Services
 
         // --- MÉTODOS PRIVADOS DE ACESSO AO ARQUIVO ---
 
-        private static async Task<List<IDEDTO>> LerListaDoArquivoAsync(bool locked = false)
+        private async Task<List<IDEDTO>> LerListaDoArquivoAsync(bool locked = false)
         {
             if (!locked) await _semaphore.WaitAsync();
             try
             {
-                if (!File.Exists(FilePath)) return [];
+                if (!File.Exists(_filePath)) return [];
 
-                var jsonString = await File.ReadAllTextAsync(FilePath);
+                var jsonString = await File.ReadAllTextAsync(_filePath);
                 if (string.IsNullOrWhiteSpace(jsonString)) return [];
                 return JsonSerializer.Deserialize<List<IDEDTO>>(jsonString) ?? [];
             }
@@ -137,7 +142,7 @@ namespace ProjectManagerWeb.src.Services
             try
             {
                 var jsonString = JsonSerializer.Serialize(ides, _jsonOptions);
-                await File.WriteAllTextAsync(FilePath, jsonString);
+                await File.WriteAllTextAsync(_filePath, jsonString);
             }
             finally
             {

--- a/backend/src/Services/IDEJsonService.cs
+++ b/backend/src/Services/IDEJsonService.cs
@@ -4,7 +4,7 @@ using ProjectManagerWeb.src.Utils;
 
 namespace ProjectManagerWeb.src.Services
 {
-    public class IDEJsonService
+    public class IDEJsonService : IIDEJsonService
     {
         private static readonly string BasePath = PathHelper.BancoPath;
 

--- a/backend/src/Services/IGitCommandRunner.cs
+++ b/backend/src/Services/IGitCommandRunner.cs
@@ -1,0 +1,8 @@
+namespace ProjectManagerWeb.src.Services;
+
+public interface IGitCommandRunner
+{
+    Task<ComandoResultado> RunAsync(string command, string? sshKey = null);
+}
+
+public sealed record ComandoResultado(string Output, string Error, int ExitCode);

--- a/backend/src/Services/IIDEJsonService.cs
+++ b/backend/src/Services/IIDEJsonService.cs
@@ -1,0 +1,12 @@
+using ProjectManagerWeb.src.DTOs;
+
+namespace ProjectManagerWeb.src.Services;
+
+public interface IIDEJsonService
+{
+    Task<List<IDEDTO>> GetAllAsync();
+    Task<IDEDTO?> GetByIdAsync(Guid identificador);
+    Task<IDEDTO> AddAsync(IDEDTO novaIDE);
+    Task<bool> UpdateAsync(Guid identificador, IDEDTO atualizada);
+    Task<bool> DeleteAsync(Guid identificador);
+}

--- a/backend/src/Services/PastaJsonService.cs
+++ b/backend/src/Services/PastaJsonService.cs
@@ -8,18 +8,23 @@ namespace ProjectManagerWeb.src.Services
     {
         private static readonly string BasePath = PathHelper.BancoPath;
 
-        private static readonly string FilePath =
-            Path.Combine(BasePath, "pastas.json");
-
         private static readonly SemaphoreSlim _semaphore = new(1, 1);
         private readonly JsonSerializerOptions _jsonOptions = new() { WriteIndented = true };
+        private readonly string _filePath;
 
         public PastaJsonService()
         {
+            _filePath = Path.Combine(BasePath, "pastas.json");
+
             if (!Directory.Exists(BasePath))
             {
                 Directory.CreateDirectory(BasePath);
             }
+        }
+
+        internal PastaJsonService(string testFilePath) : this()
+        {
+            _filePath = testFilePath;
         }
 
         // --- MÉTODOS PÚBLICOS DO CRUD ---
@@ -51,14 +56,12 @@ namespace ProjectManagerWeb.src.Services
             {
                 var pastas = await LerListaDoArquivoAsync(locked: true);
 
-                if (pastas.Exists(pasta => pasta.Diretorio.Equals(novaPasta.Diretorio, StringComparison.OrdinalIgnoreCase)))
-                    await DeleteAsync(novaPasta.Diretorio);
+                pastas.RemoveAll(p => p.Diretorio.Equals(novaPasta.Diretorio, StringComparison.OrdinalIgnoreCase));
 
-                var pastaParaAdicionar = novaPasta;
-                pastas.Add(pastaParaAdicionar);
+                pastas.Add(novaPasta);
                 await GravarListaNoArquivoAsync(pastas, locked: true);
 
-                return pastaParaAdicionar;
+                return novaPasta;
             }
             finally
             {
@@ -127,14 +130,14 @@ namespace ProjectManagerWeb.src.Services
 
         // --- MÉTODOS PRIVADOS DE ACESSO AO ARQUIVO ---
 
-        private static async Task<List<PastaCadastroRequestDTO>> LerListaDoArquivoAsync(bool locked = false)
+        private async Task<List<PastaCadastroRequestDTO>> LerListaDoArquivoAsync(bool locked = false)
         {
             if (!locked) await _semaphore.WaitAsync();
             try
             {
-                if (!File.Exists(FilePath)) return [];
+                if (!File.Exists(_filePath)) return [];
 
-                var jsonString = await File.ReadAllTextAsync(FilePath);
+                var jsonString = await File.ReadAllTextAsync(_filePath);
                 if (string.IsNullOrWhiteSpace(jsonString)) return [];
                 return JsonSerializer.Deserialize<List<PastaCadastroRequestDTO>>(jsonString) ?? [];
             }
@@ -150,7 +153,7 @@ namespace ProjectManagerWeb.src.Services
             try
             {
                 var jsonString = JsonSerializer.Serialize(pastas, _jsonOptions);
-                await File.WriteAllTextAsync(FilePath, jsonString);
+                await File.WriteAllTextAsync(_filePath, jsonString);
             }
             finally
             {

--- a/backend/src/Services/RepositorioJsonService.cs
+++ b/backend/src/Services/RepositorioJsonService.cs
@@ -8,9 +8,6 @@ namespace ProjectManagerWeb.src.Services
     {
         private static readonly string BasePath = PathHelper.BancoPath;
 
-        private static readonly string FilePath =
-            Path.Combine(BasePath, "repositorios.json");
-
         private static readonly SemaphoreSlim _semaphore = new(1, 1);
         private readonly JsonSerializerOptions _jsonOptions = new()
         {
@@ -18,12 +15,21 @@ namespace ProjectManagerWeb.src.Services
             PropertyNameCaseInsensitive = true
         };
 
+        private readonly string _filePath;
+
         public RepositorioJsonService()
         {
+            _filePath = Path.Combine(BasePath, "repositorios.json");
+
             if (!Directory.Exists(BasePath))
             {
                 Directory.CreateDirectory(BasePath);
             }
+        }
+
+        internal RepositorioJsonService(string testFilePath) : this()
+        {
+            _filePath = testFilePath;
         }
 
         // --- MÉTODOS PÚBLICOS DO CRUD ---
@@ -172,14 +178,14 @@ namespace ProjectManagerWeb.src.Services
 
         // --- MÉTODOS PRIVADOS DE ACESSO AO ARQUIVO ---
 
-        private static async Task<List<RepositorioRequestDTO>> LerListaDoArquivoAsync(bool locked = false)
+        private async Task<List<RepositorioRequestDTO>> LerListaDoArquivoAsync(bool locked = false)
         {
             if (!locked) await _semaphore.WaitAsync();
             try
             {
-                if (!File.Exists(FilePath)) return [];
+                if (!File.Exists(_filePath)) return [];
 
-                var jsonString = await File.ReadAllTextAsync(FilePath);
+                var jsonString = await File.ReadAllTextAsync(_filePath);
                 if (string.IsNullOrWhiteSpace(jsonString)) return [];
 
                 var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
@@ -197,7 +203,7 @@ namespace ProjectManagerWeb.src.Services
             try
             {
                 var jsonString = JsonSerializer.Serialize(repositorios, _jsonOptions);
-                await File.WriteAllTextAsync(FilePath, jsonString);
+                await File.WriteAllTextAsync(_filePath, jsonString);
             }
             finally
             {

--- a/backend/src/Services/SiteIISJsonService.cs
+++ b/backend/src/Services/SiteIISJsonService.cs
@@ -8,18 +8,23 @@ namespace ProjectManagerWeb.src.Services
     {
         private static readonly string BasePath = PathHelper.BancoPath;
 
-        private static readonly string FilePath =
-            Path.Combine(BasePath, "sites-iis.json");
-
         private static readonly SemaphoreSlim _semaphore = new(1, 1);
         private readonly JsonSerializerOptions _jsonOptions = new() { WriteIndented = true };
+        private readonly string _filePath;
 
         public SiteIISJsonService()
         {
+            _filePath = Path.Combine(BasePath, "sites-iis.json");
+
             if (!Directory.Exists(BasePath))
             {
                 Directory.CreateDirectory(BasePath);
             }
+        }
+
+        internal SiteIISJsonService(string testFilePath) : this()
+        {
+            _filePath = testFilePath;
         }
 
         // --- MÉTODOS PÚBLICOS DO CRUD ---
@@ -104,14 +109,14 @@ namespace ProjectManagerWeb.src.Services
 
         // --- MÉTODOS PRIVADOS DE ACESSO AO ARQUIVO ---
 
-        private static async Task<List<SiteIISRequestDTO>> LerListaDoArquivoAsync(bool locked = false)
+        private async Task<List<SiteIISRequestDTO>> LerListaDoArquivoAsync(bool locked = false)
         {
             if (!locked) await _semaphore.WaitAsync();
             try
             {
-                if (!File.Exists(FilePath)) return [];
+                if (!File.Exists(_filePath)) return [];
 
-                var jsonString = await File.ReadAllTextAsync(FilePath);
+                var jsonString = await File.ReadAllTextAsync(_filePath);
                 if (string.IsNullOrWhiteSpace(jsonString)) return [];
                 return JsonSerializer.Deserialize<List<SiteIISRequestDTO>>(jsonString) ?? [];
             }
@@ -127,7 +132,7 @@ namespace ProjectManagerWeb.src.Services
             try
             {
                 var jsonString = JsonSerializer.Serialize(sites, _jsonOptions);
-                await File.WriteAllTextAsync(FilePath, jsonString);
+                await File.WriteAllTextAsync(_filePath, jsonString);
             }
             finally
             {

--- a/backend/src/Services/VersaoService.cs
+++ b/backend/src/Services/VersaoService.cs
@@ -77,8 +77,8 @@ public class VersaoService(HttpClient httpClient)
         var infoVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
         if (infoVersion is not null)
         {
-            var idx = infoVersion.IndexOf('+');
-            return idx >= 0 ? infoVersion[..idx] : infoVersion;
+            var match = System.Text.RegularExpressions.Regex.Match(infoVersion, @"\d+\.\d+\.\d+");
+            if (match.Success) return match.Value;
         }
         var version = assembly.GetName().Version;
         return version is null ? "0.0.0" : $"{version.Major}.{version.Minor}.{version.Build}";

--- a/backend/src/Services/VersaoService.cs
+++ b/backend/src/Services/VersaoService.cs
@@ -84,7 +84,7 @@ public class VersaoService(HttpClient httpClient)
         return version is null ? "0.0.0" : $"{version.Major}.{version.Minor}.{version.Build}";
     }
 
-    private static int CompararVersao(string a, string b)
+    internal static int CompararVersao(string a, string b)
     {
         var partesA = a.Split('.');
         var partesB = b.Split('.');

--- a/backend/src/Services/VersaoService.cs
+++ b/backend/src/Services/VersaoService.cs
@@ -75,7 +75,11 @@ public class VersaoService(HttpClient httpClient)
     {
         var assembly = Assembly.GetExecutingAssembly();
         var infoVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
-        if (infoVersion is not null) return infoVersion;
+        if (infoVersion is not null)
+        {
+            var idx = infoVersion.IndexOf('+');
+            return idx >= 0 ? infoVersion[..idx] : infoVersion;
+        }
         var version = assembly.GetName().Version;
         return version is null ? "0.0.0" : $"{version.Major}.{version.Minor}.{version.Build}";
     }

--- a/backend/src/Utils/IShellExecutor.cs
+++ b/backend/src/Utils/IShellExecutor.cs
@@ -1,0 +1,7 @@
+namespace ProjectManagerWeb.src.Utils;
+
+public interface IShellExecutor
+{
+    void ExecutarComando(string command, string? perfilTerminal = null, string? githubToken = null);
+    void ExecutarComandoSemInterface(string command);
+}

--- a/backend/src/Utils/LinuxShellProvider.cs
+++ b/backend/src/Utils/LinuxShellProvider.cs
@@ -78,7 +78,7 @@ public class LinuxShellProvider(ConfiguracaoService configuracaoService) : IShel
         }
     }
 
-    private static string RemoverMarcadorExit(string command)
+    internal static string RemoverMarcadorExit(string command)
     {
         var trimmed = command.TrimEnd();
         if (trimmed.EndsWith("Exit;", StringComparison.OrdinalIgnoreCase))
@@ -125,7 +125,7 @@ public class LinuxShellProvider(ConfiguracaoService configuracaoService) : IShel
     private static string EscapeBash(string command) =>
         command.Replace("\"", "\\\"");
 
-    private static string? ExtrairDiretorioDoComando(string command)
+    internal static string? ExtrairDiretorioDoComando(string command)
     {
         var match = Regex.Match(command, @"cd\s+""([^""]+)""");
         return match.Success ? match.Groups[1].Value : null;

--- a/backend/src/Utils/ShellExecutor.cs
+++ b/backend/src/Utils/ShellExecutor.cs
@@ -1,0 +1,14 @@
+namespace ProjectManagerWeb.src.Utils;
+
+public class ShellExecutor : IShellExecutor
+{
+    public void ExecutarComando(string command, string? perfilTerminal = null, string? githubToken = null)
+    {
+        ShellExecute.ExecutarComando(command, perfilTerminal, githubToken);
+    }
+
+    public void ExecutarComandoSemInterface(string command)
+    {
+        ShellExecute.ExecutarComandoSemInterface(command);
+    }
+}

--- a/backend/src/Utils/Terminais/GhosttyTerminal.cs
+++ b/backend/src/Utils/Terminais/GhosttyTerminal.cs
@@ -8,7 +8,7 @@ public class GhosttyTerminal : ITerminalEmulator
     {
         var trimmed = command.TrimEnd(' ', ';');
         var execBash = !string.IsNullOrWhiteSpace(workingDirectory)
-            ? $"cd \"{EscapeBash(workingDirectory)}\" && exec bash"
+            ? $"cd '{EscapeBash(workingDirectory)}' && exec bash"
             : "exec bash";
 
         Process.Start(new ProcessStartInfo

--- a/backend/src/Utils/Terminais/PtyxisTerminal.cs
+++ b/backend/src/Utils/Terminais/PtyxisTerminal.cs
@@ -8,7 +8,7 @@ public class PtyxisTerminal : ITerminalEmulator
     {
         var trimmed = command.TrimEnd(' ', ';');
         var execBash = !string.IsNullOrWhiteSpace(workingDirectory)
-            ? $"cd \"{EscapeBash(workingDirectory)}\" && exec bash"
+            ? $"cd '{EscapeBash(workingDirectory)}' && exec bash"
             : "exec bash";
         string args;
 

--- a/backend/test-coverage.sh
+++ b/backend/test-coverage.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+COVERAGE_DIR="$SCRIPT_DIR/tests/CoverageResults"
+REPORT_DIR="$SCRIPT_DIR/tests/CoverageReport"
+
+echo "=== Rodando testes com cobertura ==="
+dotnet test "$SCRIPT_DIR/tests/ProjectManagerWeb.Tests/ProjectManagerWeb.Tests.csproj" \
+  --collect:"XPlat Code Coverage" \
+  --settings "$SCRIPT_DIR/Coverage.runsettings" \
+  --results-directory "$COVERAGE_DIR" \
+  --nologo \
+  --verbosity minimal
+
+echo "=== Gerando relatório HTML ==="
+dotnet reportgenerator \
+  "-reports:$COVERAGE_DIR/**/coverage.cobertura.xml" \
+  "-targetdir:$REPORT_DIR" \
+  -reporttypes:Html
+
+echo ""
+echo "Relatório de cobertura:"
+echo "  $REPORT_DIR/index.html"
+echo ""
+
+# Extrai a porcentagem total do último relatório gerado
+if [ -f "$REPORT_DIR/index.html" ]; then
+  COVERAGE=$(grep -oP 'Line coverage: \K[0-9.]+(?=%)' "$REPORT_DIR/index.html" | head -1 || echo "N/A")
+  echo "Cobertura de linha: $COVERAGE%"
+fi

--- a/backend/tests/ProjectManagerWeb.Tests/ProjectManagerWeb.Tests.csproj
+++ b/backend/tests/ProjectManagerWeb.Tests/ProjectManagerWeb.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="NSubstitute" Version="5.1.0" />
+    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\ProjectManagerWeb.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <Using Include="FluentAssertions" />
+    <Using Include="NSubstitute" />
+  </ItemGroup>
+
+</Project>

--- a/backend/tests/ProjectManagerWeb.Tests/Services/CloneServiceTests.cs
+++ b/backend/tests/ProjectManagerWeb.Tests/Services/CloneServiceTests.cs
@@ -1,0 +1,232 @@
+using ProjectManagerWeb.src.DTOs;
+using ProjectManagerWeb.src.Services;
+
+namespace ProjectManagerWeb.Tests.Services;
+
+public class CloneServiceTests
+{
+    private readonly IGitCommandRunner _gitRunner = Substitute.For<IGitCommandRunner>();
+    private readonly RepositorioJsonService _repositorioJson = Substitute.For<RepositorioJsonService>();
+    private readonly CloneService _sut;
+
+    public CloneServiceTests()
+    {
+        _sut = new CloneService(_repositorioJson, _gitRunner);
+    }
+
+    public class VerificarBranchExisteAsync : CloneServiceTests
+    {
+        [Fact]
+        public async Task Deve_retornar_false_com_mensagem_do_git_quando_git_falha()
+        {
+            _gitRunner.RunAsync(Arg.Any<string>(), Arg.Any<string>())
+                .Returns(new ComandoResultado(string.Empty, "fatal: not found", 128));
+
+            var (existe, erro) = await _sut.VerificarBranchExisteAsync("url", "branch");
+
+            existe.Should().BeFalse();
+            erro.Should().Be("fatal: not found");
+        }
+
+        [Fact]
+        public async Task Deve_retornar_false_com_mensagem_padrao_quando_git_falha_sem_mensagem()
+        {
+            _gitRunner.RunAsync(Arg.Any<string>(), Arg.Any<string>())
+                .Returns(new ComandoResultado(string.Empty, string.Empty, 1));
+
+            var (existe, erro) = await _sut.VerificarBranchExisteAsync("url", "branch");
+
+            existe.Should().BeFalse();
+            erro.Should().Be("Falha ao consultar repositório remoto");
+        }
+
+        [Fact]
+        public async Task Deve_retornar_false_sem_mensagem_quando_branch_nao_existe()
+        {
+            _gitRunner.RunAsync(Arg.Any<string>(), Arg.Any<string>())
+                .Returns(new ComandoResultado(string.Empty, string.Empty, 0));
+
+            var (existe, erro) = await _sut.VerificarBranchExisteAsync("url", "branch");
+
+            existe.Should().BeFalse();
+            erro.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task Deve_retornar_true_quando_branch_existe()
+        {
+            _gitRunner.RunAsync(Arg.Any<string>(), Arg.Any<string>())
+                .Returns(new ComandoResultado("abc123\thead", string.Empty, 0));
+
+            var (existe, erro) = await _sut.VerificarBranchExisteAsync("url", "branch");
+
+            existe.Should().BeTrue();
+            erro.Should().BeNull();
+        }
+    }
+
+    public class DetectarBranchPrincipalAsync : CloneServiceTests
+    {
+        [Fact]
+        public async Task Deve_retornar_vazio_quando_git_falha_ao_consultar()
+        {
+            _gitRunner.RunAsync(Arg.Any<string>(), Arg.Any<string>())
+                .Returns(new ComandoResultado(string.Empty, string.Empty, 1));
+
+            var resultado = await _sut.DetectarBranchPrincipalAsync("url");
+
+            resultado.Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task Deve_retornar_vazio_quando_remoto_nao_tem_head()
+        {
+            _gitRunner.RunAsync(Arg.Any<string>(), Arg.Any<string>())
+                .Returns(new ComandoResultado("abc123\thead", string.Empty, 0));
+
+            var resultado = await _sut.DetectarBranchPrincipalAsync("url");
+
+            resultado.Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task Deve_retornar_main_quando_branch_padrao_eh_main()
+        {
+            _gitRunner.RunAsync(Arg.Any<string>(), Arg.Any<string>())
+                .Returns(new ComandoResultado("ref: refs/heads/main\tHEAD", string.Empty, 0));
+
+            var resultado = await _sut.DetectarBranchPrincipalAsync("url");
+
+            resultado.Should().Be("main");
+        }
+
+        [Fact]
+        public async Task Deve_retornar_develop_quando_branch_padrao_eh_develop()
+        {
+            _gitRunner.RunAsync(Arg.Any<string>(), Arg.Any<string>())
+                .Returns(new ComandoResultado("ref: refs/heads/develop\tHEAD\nabc123\thead", string.Empty, 0));
+
+            var resultado = await _sut.DetectarBranchPrincipalAsync("url");
+
+            resultado.Should().Be("develop");
+        }
+    }
+
+    public class EhBranchBase : CloneServiceTests
+    {
+        [Theory]
+        [InlineData("main", true)]
+        [InlineData("master", true)]
+        [InlineData("develop", true)]
+        [InlineData("dev", true)]
+        [InlineData("feature/nova", false)]
+        [InlineData("fix/bug", false)]
+        [InlineData("release", false)]
+        public void Deve_considerar_base_apenas_main_master_develop_dev(string branch, bool esperado)
+        {
+            CloneService.EhBranchBase(branch).Should().Be(esperado);
+        }
+    }
+
+    public class MontarScript : CloneServiceTests
+    {
+        private static CloneRequestDTO CriarClone(string branch, string tipo = "feature", bool criarBranchRemoto = false, bool historicoCompleto = false)
+            => new("/raiz", "FAT-123", "descricao", tipo, branch, Guid.NewGuid(), criarBranchRemoto, false, false, historicoCompleto);
+
+        [Fact]
+        public void Deve_gerar_clone_com_filter_e_single_branch_quando_branch_base()
+        {
+            var clone = CriarClone("main");
+
+            var script = CloneService.MontarScript("/raiz/FAT-123_descricao", "url", "repo", clone);
+
+            script.Should().Contain("git clone --filter=blob:none --single-branch --branch main \"url\"");
+            script.Should().Contain("cd \"/raiz/FAT-123_descricao\"");
+            script.Should().Contain("cd \"repo\"");
+        }
+
+        [Fact]
+        public void Deve_clonar_main_primeiro_e_depois_fazer_fetch_quando_branch_nao_eh_base()
+        {
+            var clone = CriarClone("feature/nova");
+
+            var script = CloneService.MontarScript("/raiz/FAT-123_descricao", "url", "repo", clone, "main");
+
+            script.Should().Contain("git clone --filter=blob:none --single-branch --branch main \"url\"");
+            script.Should().Contain("git fetch origin feature/nova");
+            script.Should().Contain("git checkout -b feature/nova FETCH_HEAD");
+        }
+
+        [Fact]
+        public void Nao_deve_usar_filter_quando_historico_completo()
+        {
+            var clone = CriarClone("main", historicoCompleto: true);
+
+            var script = CloneService.MontarScript("/raiz/FAT-123_descricao", "url", "repo", clone);
+
+            script.Should().NotContain("--filter=blob:none");
+            script.Should().Contain("git clone --branch main");
+        }
+
+        [Fact]
+        public void Deve_criar_branch_com_apenas_codigo_quando_tipo_eh_nenhum()
+        {
+            var clone = CriarClone("main", "nenhum", criarBranchRemoto: true);
+
+            var script = CloneService.MontarScript("/raiz/FAT-123_descricao", "url", "repo", clone);
+
+            script.Should().Contain("git checkout -b FAT-123");
+        }
+
+        [Fact]
+        public void Deve_criar_branch_com_prefixo_do_tipo_quando_tipo_informado()
+        {
+            var clone = CriarClone("main", "feature", criarBranchRemoto: true);
+
+            var script = CloneService.MontarScript("/raiz/FAT-123_descricao", "url", "repo", clone);
+
+            script.Should().Contain("git checkout -b feature/FAT-123");
+        }
+
+        [Fact]
+        public void Nao_deve_gerar_checkout_quando_nao_deve_criar_branch_remoto()
+        {
+            var clone = CriarClone("main");
+
+            var script = CloneService.MontarScript("/raiz/FAT-123_descricao", "url", "repo", clone);
+
+            script.Should().NotContain("git checkout -b");
+        }
+    }
+
+    public class FiltrarWarnings : CloneServiceTests
+    {
+        [Fact]
+        public void Deve_retornar_vazio_quando_stderr_eh_vazio()
+        {
+            var resultado = GitCommandRunner.FiltrarWarnings(string.Empty);
+
+            resultado.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void Deve_remover_linhas_de_environment_variable()
+        {
+            var stderr = "Environment variable $HOME not set\nreal error message";
+
+            var resultado = GitCommandRunner.FiltrarWarnings(stderr);
+
+            resultado.Should().Be("real error message");
+        }
+
+        [Fact]
+        public void Deve_retornar_mesmo_texto_quando_nao_tem_environment_variable()
+        {
+            var stderr = "error: something went wrong";
+
+            var resultado = GitCommandRunner.FiltrarWarnings(stderr);
+
+            resultado.Should().Be("error: something went wrong");
+        }
+    }
+}

--- a/backend/tests/ProjectManagerWeb.Tests/Services/ComandoServiceTests.cs
+++ b/backend/tests/ProjectManagerWeb.Tests/Services/ComandoServiceTests.cs
@@ -1,0 +1,163 @@
+using ProjectManagerWeb.src.DTOs;
+using ProjectManagerWeb.src.Services;
+using ProjectManagerWeb.src.Utils;
+
+namespace ProjectManagerWeb.Tests.Services;
+
+public class ComandoServiceTests
+{
+    private readonly RepositorioJsonService _repositorioJson = Substitute.For<RepositorioJsonService>();
+    private readonly IIDEJsonService _ideJson = Substitute.For<IIDEJsonService>();
+    private readonly IShellExecutor _shell = Substitute.For<IShellExecutor>();
+    private readonly ComandoService _sut;
+
+    public ComandoServiceTests()
+    {
+        _sut = new ComandoService(_repositorioJson, _ideJson, _shell);
+    }
+
+    public class ObterAlvoIDE : ComandoServiceTests
+    {
+        [Fact]
+        public void Deve_retornar_ponto_quando_workspace_desabilitado()
+        {
+            var alvo = ComandoService.ObterAlvoIDE("/tmp/dir", false);
+
+            alvo.Should().Be(".");
+        }
+
+        [Fact]
+        public void Deve_retornar_ponto_quando_diretorio_nao_existe()
+        {
+            var alvo = ComandoService.ObterAlvoIDE("/tmp/dir_inexistente", true);
+
+            alvo.Should().Be(".");
+        }
+
+        [Fact]
+        public void Deve_retornar_ponto_quando_diretorio_existe_mas_sem_workspace()
+        {
+            var alvo = ComandoService.ObterAlvoIDE(Path.GetTempPath(), true);
+
+            alvo.Should().Be(".");
+        }
+
+        [Fact]
+        public void Deve_retornar_caminho_do_workspace_quando_existe_arquivo_code_workspace()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "test-workspace-" + Guid.NewGuid());
+            Directory.CreateDirectory(dir);
+            var workspacePath = Path.Combine(dir, "projeto.code-workspace");
+            File.WriteAllText(workspacePath, "{}");
+
+            var alvo = ComandoService.ObterAlvoIDE(dir, true);
+
+            alvo.Should().Be($"\"{workspacePath}\"");
+
+            Directory.Delete(dir, true);
+        }
+    }
+
+    public class ExecutarComandoAvulso : ComandoServiceTests
+    {
+        [Fact]
+        public void Deve_retornar_true_quando_comando_executa_com_sucesso()
+        {
+            var resultado = _sut.ExecutarComandoAvulso("echo hello");
+
+            resultado.Should().BeTrue();
+            _shell.Received(1).ExecutarComando("echo hello", null, null);
+        }
+
+        [Fact]
+        public void Deve_retornar_false_quando_shell_lanca_excecao()
+        {
+            _shell.When(x => x.ExecutarComando(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>()))
+                .Do(_ => throw new Exception("erro simulado"));
+
+            var resultado = _sut.ExecutarComandoAvulso("comando que falha");
+
+            resultado.Should().BeFalse();
+        }
+
+        [Fact]
+        public void Deve_passar_token_e_perfil_para_o_shell()
+        {
+            _sut.ExecutarComandoAvulso("echo hello", "perfil-x", "token-abc");
+
+            _shell.Received(1).ExecutarComando("echo hello", "perfil-x", "token-abc");
+        }
+    }
+
+    public class AbrirPastaIDE : ComandoServiceTests
+    {
+        private readonly Guid _ideId = Guid.NewGuid();
+
+        [Fact]
+        public async Task Deve_lancar_excecao_quando_ide_nao_encontrada()
+        {
+            _ideJson.GetByIdAsync(_ideId).Returns((IDEDTO?)null);
+
+            var request = new AbrirPastaIDERequestDTO("/tmp/dir", _ideId);
+            var act = () => _sut.AbrirPastaIDE(request);
+
+            await act.Should().ThrowAsync<Exception>().WithMessage("IDE não encontrada");
+        }
+
+        [Fact]
+        public async Task Deve_chamar_executar_comando_sem_interface_quando_ide_existe()
+        {
+            var ide = new IDEDTO(_ideId, "VS Code", "code", true);
+            _ideJson.GetByIdAsync(_ideId).Returns(ide);
+
+            var request = new AbrirPastaIDERequestDTO("/tmp/dir", _ideId);
+            var resultado = await _sut.AbrirPastaIDE(request);
+
+            resultado.Should().BeTrue();
+            _shell.Received(1).ExecutarComandoSemInterface(Arg.Is<string>(c =>
+                c.Contains("cd \"/tmp/dir\"") && c.Contains("code .") && c.Contains("Exit;")));
+        }
+
+        [Fact]
+        public async Task Deve_incluir_perfil_vscode_quando_ide_aceita_e_perfil_informado()
+        {
+            var ide = new IDEDTO(_ideId, "VS Code", "code", true);
+            _ideJson.GetByIdAsync(_ideId).Returns(ide);
+
+            var request = new AbrirPastaIDERequestDTO("/tmp/dir", _ideId, "perfil-web");
+            var resultado = await _sut.AbrirPastaIDE(request);
+
+            resultado.Should().BeTrue();
+            _shell.Received(1).ExecutarComandoSemInterface(Arg.Is<string>(c =>
+                c.Contains("--profile \"perfil-web\"") && c.Contains("code")));
+        }
+
+        [Fact]
+        public async Task Nao_deve_incluir_perfil_quando_ide_nao_aceita_perfil()
+        {
+            var ide = new IDEDTO(_ideId, "Kiro", "kiro", false);
+            _ideJson.GetByIdAsync(_ideId).Returns(ide);
+
+            var request = new AbrirPastaIDERequestDTO("/tmp/dir", _ideId, "perfil-web");
+            var resultado = await _sut.AbrirPastaIDE(request);
+
+            resultado.Should().BeTrue();
+            _shell.Received(1).ExecutarComandoSemInterface(Arg.Is<string>(c =>
+                c.Contains("kiro .") && !c.Contains("--profile")));
+        }
+
+        [Fact]
+        public async Task Deve_retornar_false_quando_shell_lanca_excecao()
+        {
+            var ide = new IDEDTO(_ideId, "VS Code", "code", true);
+            _ideJson.GetByIdAsync(_ideId).Returns(ide);
+            _shell.When(x => x.ExecutarComandoSemInterface(Arg.Any<string>()))
+                .Do(_ => throw new Exception("erro simulado"));
+
+            var request = new AbrirPastaIDERequestDTO("/tmp/dir", _ideId);
+            var resultado = await _sut.AbrirPastaIDE(request);
+
+            resultado.Should().BeFalse();
+        }
+    }
+}

--- a/backend/tests/ProjectManagerWeb.Tests/Services/ConfiguracaoServiceTests.cs
+++ b/backend/tests/ProjectManagerWeb.Tests/Services/ConfiguracaoServiceTests.cs
@@ -1,0 +1,263 @@
+using System.Text.Json;
+using ProjectManagerWeb.src.DTOs;
+using ProjectManagerWeb.src.Services;
+
+namespace ProjectManagerWeb.Tests.Services;
+
+public class ConfiguracaoServiceTests : IDisposable
+{
+    private readonly string _tempPath;
+    private readonly string _tempFile;
+    private readonly ConfiguracaoService _sut;
+
+    public ConfiguracaoServiceTests()
+    {
+        _tempPath = Path.Combine(Path.GetTempPath(), "pmw-tests-" + Guid.NewGuid());
+        _tempFile = Path.Combine(_tempPath, "Configuracao.json");
+        Directory.CreateDirectory(_tempPath);
+        _sut = new ConfiguracaoService(_tempFile);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempPath))
+            Directory.Delete(_tempPath, true);
+    }
+
+    public class ObterConfiguracaoAsync : ConfiguracaoServiceTests
+    {
+        [Fact]
+        public async Task Deve_retornar_configuracao_vazia_quando_arquivo_nao_existe()
+        {
+            var config = await _sut.ObterConfiguracaoAsync();
+
+            config.Should().NotBeNull();
+            config.DiretorioRaiz.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task Deve_retornar_configuracao_vazia_quando_arquivo_esta_vazio()
+        {
+            await File.WriteAllTextAsync(_tempFile, string.Empty);
+
+            var config = await _sut.ObterConfiguracaoAsync();
+
+            config.Should().NotBeNull();
+            config.DiretorioRaiz.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task Deve_retornar_dados_salvos_quando_arquivo_existe_com_json_valido()
+        {
+            var salva = new ConfiguracaoRequestDTO { DiretorioRaiz = "/projetos" };
+            await SalvarDireto(salva);
+
+            var config = await _sut.ObterConfiguracaoAsync();
+
+            config.DiretorioRaiz.Should().Be("/projetos");
+        }
+    }
+
+    public class SalvarConfiguracaoAsync : ConfiguracaoServiceTests
+    {
+        [Fact]
+        public async Task Deve_salvar_e_ler_mesma_configuracao()
+        {
+            var original = new ConfiguracaoRequestDTO
+            {
+                DiretorioRaiz = "/meus-projetos",
+                TerminalLinux = "ghostty"
+            };
+
+            await _sut.SalvarConfiguracaoAsync(original);
+            var lida = await _sut.ObterConfiguracaoAsync();
+
+            lida.DiretorioRaiz.Should().Be("/meus-projetos");
+            lida.TerminalLinux.Should().Be("ghostty");
+        }
+    }
+
+    public class RenomearPerfilAsync : ConfiguracaoServiceTests
+    {
+        [Fact]
+        public async Task Deve_retornar_true_quando_perfil_existe_e_renomear()
+        {
+            await SalvarDireto(new ConfiguracaoRequestDTO
+            {
+                PerfisVSCode =
+                [
+                    new PerfilVSCodeRequestDTO("web"),
+                    new PerfilVSCodeRequestDTO("mobile")
+                ]
+            });
+
+            var resultado = await _sut.RenomearPerfilAsync("web", "frontend");
+
+            resultado.Should().BeTrue();
+            var config = await _sut.ObterConfiguracaoAsync();
+            config.PerfisVSCode.Should().Contain(p => p.Nome == "frontend");
+            config.PerfisVSCode.Should().NotContain(p => p.Nome == "web");
+        }
+
+        [Fact]
+        public async Task Deve_retornar_false_quando_perfil_nao_existe()
+        {
+            await SalvarDireto(new ConfiguracaoRequestDTO
+            {
+                PerfisVSCode = [new PerfilVSCodeRequestDTO("web")]
+            });
+
+            var resultado = await _sut.RenomearPerfilAsync("inexistente", "novo");
+
+            resultado.Should().BeFalse();
+        }
+    }
+
+    public class ObterDiretoriosOcultosAsync : ConfiguracaoServiceTests
+    {
+        [Fact]
+        public async Task Deve_retornar_lista_vazia_quando_nao_tem_ocultos()
+        {
+            await SalvarDireto(new ConfiguracaoRequestDTO());
+
+            var ocultos = await _sut.ObterDiretoriosOcultosAsync();
+
+            ocultos.Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task Deve_retornar_lista_quando_tem_ocultos()
+        {
+            await SalvarDireto(new ConfiguracaoRequestDTO
+            {
+                DiretoriosOcultos = ["/tmp/antigo", "/tmp/legado"]
+            });
+
+            var ocultos = await _sut.ObterDiretoriosOcultosAsync();
+
+            ocultos.Should().Contain("/tmp/antigo");
+            ocultos.Should().Contain("/tmp/legado");
+        }
+    }
+
+    public class OcultarDiretorioAsync : ConfiguracaoServiceTests
+    {
+        [Fact]
+        public async Task Deve_adicionar_diretorio_na_lista_de_ocultos()
+        {
+            await _sut.OcultarDiretorioAsync("/tmp/esconder");
+
+            var config = await _sut.ObterConfiguracaoAsync();
+            config.DiretoriosOcultos.Should().Contain("/tmp/esconder");
+        }
+
+        [Fact]
+        public async Task Nao_deve_duplicar_quando_diretorio_ja_esta_oculto()
+        {
+            await _sut.OcultarDiretorioAsync("/tmp/esconder");
+            await _sut.OcultarDiretorioAsync("/tmp/esconder");
+
+            var config = await _sut.ObterConfiguracaoAsync();
+            config.DiretoriosOcultos.Should().HaveCount(1);
+        }
+    }
+
+    public class RestaurarDiretorioAsync : ConfiguracaoServiceTests
+    {
+        [Fact]
+        public async Task Deve_remover_diretorio_da_lista_de_ocultos()
+        {
+            await SalvarDireto(new ConfiguracaoRequestDTO
+            {
+                DiretoriosOcultos = ["/tmp/a", "/tmp/b"]
+            });
+
+            await _sut.RestaurarDiretorioAsync("/tmp/a");
+
+            var config = await _sut.ObterConfiguracaoAsync();
+            config.DiretoriosOcultos.Should().NotContain("/tmp/a");
+            config.DiretoriosOcultos.Should().Contain("/tmp/b");
+        }
+
+        [Fact]
+        public async Task Nao_deve_lancar_erro_quando_diretorio_nao_esta_oculto()
+        {
+            await _sut.RestaurarDiretorioAsync("/tmp/inexistente");
+
+            var config = await _sut.ObterConfiguracaoAsync();
+            config.DiretoriosOcultos.Should().BeEmpty();
+        }
+    }
+
+    public class AdicionarPastaCentralizadoraAsync : ConfiguracaoServiceTests
+    {
+        [Fact]
+        public async Task Deve_adicionar_nova_pasta_centralizadora()
+        {
+            await _sut.AdicionarPastaCentralizadoraAsync("Projetos");
+
+            var config = await _sut.ObterConfiguracaoAsync();
+            config.PastasCentralizadoras.Should().Contain(p => p.Nome == "Projetos");
+        }
+
+        [Fact]
+        public async Task Deve_lancar_excecao_quando_nome_ja_existe()
+        {
+            await _sut.AdicionarPastaCentralizadoraAsync("Projetos");
+
+            var act = () => _sut.AdicionarPastaCentralizadoraAsync("Projetos");
+
+            await act.Should().ThrowAsync<Exception>().WithMessage("*já existe*");
+        }
+    }
+
+    public class RenomearPastaCentralizadoraAsync : ConfiguracaoServiceTests
+    {
+        [Fact]
+        public async Task Deve_renomear_pasta_existente()
+        {
+            await SalvarDireto(new ConfiguracaoRequestDTO
+            {
+                PastasCentralizadoras = [new PastaCentralizadoraDTO("Dev"), new PastaCentralizadoraDTO("Infra")]
+            });
+
+            await _sut.RenomearPastaCentralizadoraAsync("Dev", "Desenvolvimento");
+
+            var config = await _sut.ObterConfiguracaoAsync();
+            config.PastasCentralizadoras.Should().Contain(p => p.Nome == "Desenvolvimento");
+            config.PastasCentralizadoras.Should().NotContain(p => p.Nome == "Dev");
+            config.PastasCentralizadoras.Should().Contain(p => p.Nome == "Infra");
+        }
+    }
+
+    public class RemoverPastaCentralizadoraAsync : ConfiguracaoServiceTests
+    {
+        [Fact]
+        public async Task Deve_remover_pasta_existente()
+        {
+            await SalvarDireto(new ConfiguracaoRequestDTO
+            {
+                PastasCentralizadoras = [new PastaCentralizadoraDTO("Dev")]
+            });
+
+            await _sut.RemoverPastaCentralizadoraAsync("Dev");
+
+            var config = await _sut.ObterConfiguracaoAsync();
+            config.PastasCentralizadoras.Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task Deve_lancar_excecao_quando_pasta_nao_encontrada()
+        {
+            var act = () => _sut.RemoverPastaCentralizadoraAsync("Inexistente");
+
+            await act.Should().ThrowAsync<Exception>().WithMessage("*não encontrada*");
+        }
+    }
+
+    private async Task SalvarDireto(ConfiguracaoRequestDTO config)
+    {
+        var json = JsonSerializer.Serialize(config);
+        await File.WriteAllTextAsync(_tempFile, json);
+    }
+}

--- a/backend/tests/ProjectManagerWeb.Tests/Services/IDEJsonServiceTests.cs
+++ b/backend/tests/ProjectManagerWeb.Tests/Services/IDEJsonServiceTests.cs
@@ -1,0 +1,130 @@
+using System.Text.Json;
+using ProjectManagerWeb.src.DTOs;
+using ProjectManagerWeb.src.Services;
+
+namespace ProjectManagerWeb.Tests.Services;
+
+public class IDEJsonServiceTests : IDisposable
+{
+    private readonly string _tempPath;
+    private readonly string _tempFile;
+    private readonly IDEJsonService _sut;
+
+    public IDEJsonServiceTests()
+    {
+        _tempPath = Path.Combine(Path.GetTempPath(), "pmw-tests-" + Guid.NewGuid());
+        _tempFile = Path.Combine(_tempPath, "IDEs.json");
+        Directory.CreateDirectory(_tempPath);
+        _sut = new IDEJsonService(_tempFile);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempPath))
+            Directory.Delete(_tempPath, true);
+    }
+
+    private async Task SalvarDireto(List<IDEDTO> ides)
+    {
+        var json = JsonSerializer.Serialize(ides);
+        await File.WriteAllTextAsync(_tempFile, json);
+    }
+
+    private static IDEDTO CriarIDE(string nome)
+    {
+        return new IDEDTO(Guid.NewGuid(), nome, "code .", true);
+    }
+
+    public class AddAsync : IDEJsonServiceTests
+    {
+        [Fact]
+        public async Task AddAsync_lanca_excecao_quando_nome_duplicado()
+        {
+            var ide1 = CriarIDE("VS Code");
+            await _sut.AddAsync(ide1);
+
+            var ide2 = CriarIDE("VS Code");
+            var act = () => _sut.AddAsync(ide2);
+
+            await act.Should().ThrowAsync<Exception>().WithMessage("*já existe*");
+        }
+
+        [Fact]
+        public async Task AddAsync_adiciona_com_sucesso()
+        {
+            var ide = CriarIDE("VS Code");
+
+            await _sut.AddAsync(ide);
+
+            var todas = await _sut.GetAllAsync();
+            todas.Should().HaveCount(1);
+            todas[0].Nome.Should().Be("VS Code");
+        }
+    }
+
+    public class GetByIdAsync : IDEJsonServiceTests
+    {
+        [Fact]
+        public async Task GetByIdAsync_retorna_ide_quando_encontrado()
+        {
+            var ide = CriarIDE("VS Code");
+            await _sut.AddAsync(ide);
+
+            var resultado = await _sut.GetByIdAsync(ide.Identificador);
+
+            resultado.Should().NotBeNull();
+            resultado!.Identificador.Should().Be(ide.Identificador);
+        }
+
+        [Fact]
+        public async Task GetByIdAsync_retorna_null_quando_nao_encontrado()
+        {
+            var resultado = await _sut.GetByIdAsync(Guid.NewGuid());
+
+            resultado.Should().BeNull();
+        }
+    }
+
+    public class DeleteAsync : IDEJsonServiceTests
+    {
+        [Fact]
+        public async Task DeleteAsync_retorna_false_quando_nao_encontrado()
+        {
+            var resultado = await _sut.DeleteAsync(Guid.NewGuid());
+
+            resultado.Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task DeleteAsync_retorna_true_quando_remove()
+        {
+            var ide = CriarIDE("VS Code");
+            await _sut.AddAsync(ide);
+
+            var resultado = await _sut.DeleteAsync(ide.Identificador);
+
+            resultado.Should().BeTrue();
+            var todas = await _sut.GetAllAsync();
+            todas.Should().BeEmpty();
+        }
+    }
+
+    public class UpdateAsync : IDEJsonServiceTests
+    {
+        [Fact]
+        public async Task UpdateAsync_atualiza_e_preserva_identificador()
+        {
+            var ide = CriarIDE("VS Code");
+            await _sut.AddAsync(ide);
+
+            var atualizada = ide with { Nome = "VS Code Insiders", ComandoParaExecutar = "code-insiders ." };
+            var resultado = await _sut.UpdateAsync(ide.Identificador, atualizada);
+
+            resultado.Should().BeTrue();
+            var obtida = await _sut.GetByIdAsync(ide.Identificador);
+            obtida.Should().NotBeNull();
+            obtida!.Nome.Should().Be("VS Code Insiders");
+            obtida.Identificador.Should().Be(ide.Identificador);
+        }
+    }
+}

--- a/backend/tests/ProjectManagerWeb.Tests/Services/PastaJsonServiceTests.cs
+++ b/backend/tests/ProjectManagerWeb.Tests/Services/PastaJsonServiceTests.cs
@@ -1,0 +1,192 @@
+using ProjectManagerWeb.src.DTOs;
+using ProjectManagerWeb.src.Services;
+
+namespace ProjectManagerWeb.Tests.Services;
+
+public class PastaJsonServiceTests : IDisposable
+{
+    private readonly string _tempPath;
+    private readonly string _tempFile;
+    private readonly PastaJsonService _sut;
+
+    public PastaJsonServiceTests()
+    {
+        _tempPath = Path.Combine(Path.GetTempPath(), "pmw-tests-" + Guid.NewGuid());
+        _tempFile = Path.Combine(_tempPath, "pastas.json");
+        Directory.CreateDirectory(_tempPath);
+        _sut = new PastaJsonService(_tempFile);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempPath))
+            Directory.Delete(_tempPath, true);
+    }
+
+    private async Task SalvarDireto(List<PastaCadastroRequestDTO> pastas)
+    {
+        var json = System.Text.Json.JsonSerializer.Serialize(pastas);
+        await File.WriteAllTextAsync(_tempFile, json);
+    }
+
+    public class AddAsync : PastaJsonServiceTests
+    {
+        [Fact]
+        public async Task AddAsync_faz_upsert_quando_diretorio_ja_existe()
+        {
+            var pasta1 = new PastaCadastroRequestDTO(
+                Guid.NewGuid(), "/tmp/projeto", "PRJ1", "Projeto Um",
+                "feature", "main", "git@github.com:user/repo.git", Guid.NewGuid());
+
+            var pasta2 = new PastaCadastroRequestDTO(
+                Guid.NewGuid(), "/tmp/projeto", "PRJ2", "Projeto Dois Atualizado",
+                "bugfix", "develop", "git@github.com:user/repo.git", Guid.NewGuid());
+
+            await _sut.AddAsync(pasta1);
+            await _sut.AddAsync(pasta2);
+
+            var todas = await _sut.GetAllAsync();
+            todas.Should().HaveCount(1);
+            todas[0].Codigo.Should().Be("PRJ2");
+            todas[0].Descricao.Should().Be("Projeto Dois Atualizado");
+        }
+
+        [Fact]
+        public async Task AddAsync_adiciona_normal_quando_diretorio_novo()
+        {
+            var pasta1 = new PastaCadastroRequestDTO(
+                Guid.NewGuid(), "/tmp/projeto-a", "PRJ-A", "Projeto A",
+                "feature", "main", "git@github.com:user/repo.git", Guid.NewGuid());
+
+            var pasta2 = new PastaCadastroRequestDTO(
+                Guid.NewGuid(), "/tmp/projeto-b", "PRJ-B", "Projeto B",
+                "feature", "main", "git@github.com:user/repo2.git", Guid.NewGuid());
+
+            await _sut.AddAsync(pasta1);
+            await _sut.AddAsync(pasta2);
+
+            var todas = await _sut.GetAllAsync();
+            todas.Should().HaveCount(2);
+        }
+    }
+
+    public class GetByDiretorioAsync : PastaJsonServiceTests
+    {
+        [Fact]
+        public async Task GetByDiretorioAsync_retorna_null_quando_nao_encontrado()
+        {
+            var resultado = await _sut.GetByDiretorioAsync("/tmp/inexistente");
+
+            resultado.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task GetByDiretorioAsync_retorna_pasta_quando_encontrado()
+        {
+            var pasta = new PastaCadastroRequestDTO(
+                Guid.NewGuid(), "/tmp/projeto", "PRJ", "Projeto",
+                "feature", "main", "git@github.com:user/repo.git", Guid.NewGuid());
+
+            await _sut.AddAsync(pasta);
+
+            var resultado = await _sut.GetByDiretorioAsync("/tmp/projeto");
+
+            resultado.Should().NotBeNull();
+            resultado!.Identificador.Should().Be(pasta.Identificador);
+            resultado.Diretorio.Should().Be("/tmp/projeto");
+        }
+    }
+
+    public class DeleteAsync : PastaJsonServiceTests
+    {
+        [Fact]
+        public async Task DeleteAsync_retorna_false_quando_nao_encontrado()
+        {
+            var resultado = await _sut.DeleteAsync("/tmp/inexistente");
+
+            resultado.Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task DeleteAsync_retorna_true_quando_remove()
+        {
+            var pasta = new PastaCadastroRequestDTO(
+                Guid.NewGuid(), "/tmp/projeto", "PRJ", "Projeto",
+                "feature", "main", "git@github.com:user/repo.git", Guid.NewGuid());
+
+            await _sut.AddAsync(pasta);
+
+            var resultado = await _sut.DeleteAsync("/tmp/projeto");
+
+            resultado.Should().BeTrue();
+            var todas = await _sut.GetAllAsync();
+            todas.Should().BeEmpty();
+        }
+    }
+
+    public class UpdateAsync : PastaJsonServiceTests
+    {
+        [Fact]
+        public async Task UpdateAsync_retorna_false_quando_nao_encontrado()
+        {
+            var pasta = new PastaCadastroRequestDTO(
+                Guid.NewGuid(), "/tmp/projeto", "PRJ", "Projeto",
+                "feature", "main", "git@github.com:user/repo.git", Guid.NewGuid());
+
+            var resultado = await _sut.UpdateAsync("/tmp/inexistente", pasta);
+
+            resultado.Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task UpdateAsync_atualiza_e_retorna_true()
+        {
+            var pasta = new PastaCadastroRequestDTO(
+                Guid.NewGuid(), "/tmp/projeto", "PRJ", "Projeto Original",
+                "feature", "main", "git@github.com:user/repo.git", Guid.NewGuid());
+
+            await _sut.AddAsync(pasta);
+
+            var atualizada = pasta with { Descricao = "Projeto Atualizado" };
+
+            var resultado = await _sut.UpdateAsync("/tmp/projeto", atualizada);
+
+            resultado.Should().BeTrue();
+            var obtida = await _sut.GetByDiretorioAsync("/tmp/projeto");
+            obtida!.Descricao.Should().Be("Projeto Atualizado");
+        }
+    }
+
+    public class DeleteByRepositorioIdAsync : PastaJsonServiceTests
+    {
+        [Fact]
+        public async Task DeleteByRepositorioIdAsync_remove_multiplos()
+        {
+            var repoId = Guid.NewGuid();
+            var outroRepoId = Guid.NewGuid();
+
+            var pasta1 = new PastaCadastroRequestDTO(
+                Guid.NewGuid(), "/tmp/repo1-a", "R1A", "Repo1 A",
+                "feature", "main", "url", repoId);
+
+            var pasta2 = new PastaCadastroRequestDTO(
+                Guid.NewGuid(), "/tmp/repo1-b", "R1B", "Repo1 B",
+                "feature", "main", "url", repoId);
+
+            var pasta3 = new PastaCadastroRequestDTO(
+                Guid.NewGuid(), "/tmp/repo2-a", "R2A", "Repo2 A",
+                "feature", "main", "url", outroRepoId);
+
+            await _sut.AddAsync(pasta1);
+            await _sut.AddAsync(pasta2);
+            await _sut.AddAsync(pasta3);
+
+            var resultado = await _sut.DeleteByRepositorioIdAsync(repoId);
+
+            resultado.Should().BeTrue();
+            var todas = await _sut.GetAllAsync();
+            todas.Should().HaveCount(1);
+            todas[0].Identificador.Should().Be(pasta3.Identificador);
+        }
+    }
+}

--- a/backend/tests/ProjectManagerWeb.Tests/Services/RepositorioJsonServiceTests.cs
+++ b/backend/tests/ProjectManagerWeb.Tests/Services/RepositorioJsonServiceTests.cs
@@ -1,0 +1,167 @@
+using System.Text.Json;
+using ProjectManagerWeb.src.DTOs;
+using ProjectManagerWeb.src.Services;
+
+namespace ProjectManagerWeb.Tests.Services;
+
+public class RepositorioJsonServiceTests : IDisposable
+{
+    private readonly string _tempPath;
+    private readonly string _tempFile;
+    private readonly RepositorioJsonService _sut;
+
+    public RepositorioJsonServiceTests()
+    {
+        _tempPath = Path.Combine(Path.GetTempPath(), "pmw-tests-" + Guid.NewGuid());
+        _tempFile = Path.Combine(_tempPath, "repositorios.json");
+        Directory.CreateDirectory(_tempPath);
+        _sut = new RepositorioJsonService(_tempFile);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempPath))
+            Directory.Delete(_tempPath, true);
+    }
+
+    private async Task SalvarDireto(List<RepositorioRequestDTO> repositorios)
+    {
+        var json = JsonSerializer.Serialize(repositorios);
+        await File.WriteAllTextAsync(_tempFile, json);
+    }
+
+    private static RepositorioRequestDTO CriarRepositorio(string url, string nome)
+    {
+        return new RepositorioRequestDTO(
+            Guid.NewGuid(), url, nome, nome,
+            null, "main", [], null, null, null);
+    }
+
+    public class AddAsync : RepositorioJsonServiceTests
+    {
+        [Fact]
+        public async Task AddAsync_lanca_excecao_quando_url_duplicada()
+        {
+            var repo = CriarRepositorio("https://github.com/user/repo.git", "Repo1");
+
+            await _sut.AddAsync(repo);
+
+            var act = () => _sut.AddAsync(repo);
+
+            await act.Should().ThrowAsync<Exception>().WithMessage("*já existe*");
+        }
+
+        [Fact]
+        public async Task AddAsync_adiciona_com_sucesso()
+        {
+            var repo = CriarRepositorio("https://github.com/user/repo.git", "Repo1");
+
+            await _sut.AddAsync(repo);
+
+            var todos = await _sut.GetAllAsync();
+            todos.Should().HaveCount(1);
+            todos[0].Url.Should().Be("https://github.com/user/repo.git");
+        }
+    }
+
+    public class GetByIdAsync : RepositorioJsonServiceTests
+    {
+        [Fact]
+        public async Task GetByIdAsync_retorna_repositorio_quando_encontrado()
+        {
+            var repo = CriarRepositorio("https://github.com/user/repo.git", "Repo1");
+            await _sut.AddAsync(repo);
+
+            var resultado = await _sut.GetByIdAsync(repo.Identificador);
+
+            resultado.Should().NotBeNull();
+            resultado!.Identificador.Should().Be(repo.Identificador);
+        }
+
+        [Fact]
+        public async Task GetByIdAsync_retorna_null_quando_nao_encontrado()
+        {
+            var resultado = await _sut.GetByIdAsync(Guid.NewGuid());
+
+            resultado.Should().BeNull();
+        }
+    }
+
+    public class DeleteAsync : RepositorioJsonServiceTests
+    {
+        [Fact]
+        public async Task DeleteAsync_retorna_false_quando_nao_encontrado()
+        {
+            var resultado = await _sut.DeleteAsync(Guid.NewGuid());
+
+            resultado.Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task DeleteAsync_retorna_true_quando_remove()
+        {
+            var repo = CriarRepositorio("https://github.com/user/repo.git", "Repo1");
+            await _sut.AddAsync(repo);
+
+            var resultado = await _sut.DeleteAsync(repo.Identificador);
+
+            resultado.Should().BeTrue();
+            var todos = await _sut.GetAllAsync();
+            todos.Should().BeEmpty();
+        }
+    }
+
+    public class UpdateAsync : RepositorioJsonServiceTests
+    {
+        [Fact]
+        public async Task UpdateAsync_retorna_false_quando_nao_encontrado()
+        {
+            var repo = CriarRepositorio("https://github.com/user/repo.git", "Repo1");
+
+            var resultado = await _sut.UpdateAsync(Guid.NewGuid(), repo);
+
+            resultado.Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task UpdateAsync_atualiza_e_preserva_identificador()
+        {
+            var repo = CriarRepositorio("https://github.com/user/repo.git", "Repo1");
+            await _sut.AddAsync(repo);
+
+            var atualizado = repo with { Nome = "Repo Atualizado" };
+            var resultado = await _sut.UpdateAsync(repo.Identificador, atualizado);
+
+            resultado.Should().BeTrue();
+            var obtido = await _sut.GetByIdAsync(repo.Identificador);
+            obtido.Should().NotBeNull();
+            obtido!.Nome.Should().Be("Repo Atualizado");
+            obtido.Identificador.Should().Be(repo.Identificador);
+        }
+    }
+
+    public class RenomearPerfilVSCodeAsync : RepositorioJsonServiceTests
+    {
+        [Fact]
+        public async Task RenomearPerfilVSCodeAsync_atualiza_no_repo_e_nos_projetos()
+        {
+            var projeto = new ProjetoDTO(
+                Guid.NewGuid(), "WebApp", "src/web", "perfil-antigo",
+                new ComandoDTO("npm i", "npm start", "npm build", null), null);
+
+            var repo = new RepositorioRequestDTO(
+                Guid.NewGuid(), "https://github.com/user/repo.git", "Repo1", "Repo1",
+                null, "main", [projeto], null, null, null,
+                PerfilVSCode: "perfil-antigo");
+
+            await _sut.AddAsync(repo);
+
+            await _sut.RenomearPerfilVSCodeAsync("perfil-antigo", "perfil-novo");
+
+            var obtido = await _sut.GetByIdAsync(repo.Identificador);
+            obtido.Should().NotBeNull();
+            obtido!.PerfilVSCode.Should().Be("perfil-novo");
+            obtido.Projetos[0].PerfilVSCode.Should().Be("perfil-novo");
+        }
+    }
+}

--- a/backend/tests/ProjectManagerWeb.Tests/Services/SiteIISJsonServiceTests.cs
+++ b/backend/tests/ProjectManagerWeb.Tests/Services/SiteIISJsonServiceTests.cs
@@ -1,0 +1,132 @@
+using System.Text.Json;
+using ProjectManagerWeb.src.DTOs;
+using ProjectManagerWeb.src.Services;
+
+namespace ProjectManagerWeb.Tests.Services;
+
+public class SiteIISJsonServiceTests : IDisposable
+{
+    private readonly string _tempPath;
+    private readonly string _tempFile;
+    private readonly SiteIISJsonService _sut;
+
+    public SiteIISJsonServiceTests()
+    {
+        _tempPath = Path.Combine(Path.GetTempPath(), "pmw-tests-" + Guid.NewGuid());
+        _tempFile = Path.Combine(_tempPath, "sites-iis.json");
+        Directory.CreateDirectory(_tempPath);
+        _sut = new SiteIISJsonService(_tempFile);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempPath))
+            Directory.Delete(_tempPath, true);
+    }
+
+    private async Task SalvarDireto(List<SiteIISRequestDTO> sites)
+    {
+        var json = JsonSerializer.Serialize(sites);
+        await File.WriteAllTextAsync(_tempFile, json);
+    }
+
+    private static SiteIISRequestDTO CriarSite(string nome, string titulo)
+    {
+        return new SiteIISRequestDTO(
+            Guid.NewGuid(), titulo, nome,
+            @"C:\inetpub\wwwroot", [], []);
+    }
+
+    public class AddAsync : SiteIISJsonServiceTests
+    {
+        [Fact]
+        public async Task AddAsync_lanca_excecao_quando_nome_duplicado()
+        {
+            var site1 = CriarSite("MeuSite", "Meu Site");
+            await _sut.AddAsync(site1);
+
+            var site2 = CriarSite("MeuSite", "Outro Título");
+            var act = () => _sut.AddAsync(site2);
+
+            await act.Should().ThrowAsync<Exception>().WithMessage("*já existe*");
+        }
+
+        [Fact]
+        public async Task AddAsync_adiciona_com_sucesso()
+        {
+            var site = CriarSite("MeuSite", "Meu Site");
+
+            await _sut.AddAsync(site);
+
+            var todos = await _sut.GetAllAsync();
+            todos.Should().HaveCount(1);
+            todos[0].Nome.Should().Be("MeuSite");
+        }
+    }
+
+    public class GetByIdAsync : SiteIISJsonServiceTests
+    {
+        [Fact]
+        public async Task GetByIdAsync_retorna_site_quando_encontrado()
+        {
+            var site = CriarSite("MeuSite", "Meu Site");
+            await _sut.AddAsync(site);
+
+            var resultado = await _sut.GetByIdAsync(site.Identificador);
+
+            resultado.Should().NotBeNull();
+            resultado!.Identificador.Should().Be(site.Identificador);
+        }
+
+        [Fact]
+        public async Task GetByIdAsync_retorna_null_quando_nao_encontrado()
+        {
+            var resultado = await _sut.GetByIdAsync(Guid.NewGuid());
+
+            resultado.Should().BeNull();
+        }
+    }
+
+    public class DeleteAsync : SiteIISJsonServiceTests
+    {
+        [Fact]
+        public async Task DeleteAsync_retorna_false_quando_nao_encontrado()
+        {
+            var resultado = await _sut.DeleteAsync(Guid.NewGuid());
+
+            resultado.Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task DeleteAsync_retorna_true_quando_remove()
+        {
+            var site = CriarSite("MeuSite", "Meu Site");
+            await _sut.AddAsync(site);
+
+            var resultado = await _sut.DeleteAsync(site.Identificador);
+
+            resultado.Should().BeTrue();
+            var todos = await _sut.GetAllAsync();
+            todos.Should().BeEmpty();
+        }
+    }
+
+    public class UpdateAsync : SiteIISJsonServiceTests
+    {
+        [Fact]
+        public async Task UpdateAsync_atualiza_e_preserva_identificador()
+        {
+            var site = CriarSite("MeuSite", "Meu Site");
+            await _sut.AddAsync(site);
+
+            var atualizado = site with { Titulo = "Meu Site Atualizado" };
+            var resultado = await _sut.UpdateAsync(site.Identificador, atualizado);
+
+            resultado.Should().BeTrue();
+            var obtido = await _sut.GetByIdAsync(site.Identificador);
+            obtido.Should().NotBeNull();
+            obtido!.Titulo.Should().Be("Meu Site Atualizado");
+            obtido.Identificador.Should().Be(site.Identificador);
+        }
+    }
+}

--- a/backend/tests/ProjectManagerWeb.Tests/Services/VersaoServiceTests.cs
+++ b/backend/tests/ProjectManagerWeb.Tests/Services/VersaoServiceTests.cs
@@ -1,0 +1,49 @@
+using ProjectManagerWeb.src.Services;
+
+namespace ProjectManagerWeb.Tests.Services;
+
+public class VersaoServiceTests
+{
+    public class CompararVersao
+    {
+        [Fact]
+        public void Deve_retornar_negativo_quando_a_menor_que_b()
+        {
+            var resultado = VersaoService.CompararVersao("1.0.0", "2.0.0");
+
+            resultado.Should().BeNegative();
+        }
+
+        [Fact]
+        public void Deve_retornar_zero_quando_a_igual_b()
+        {
+            var resultado = VersaoService.CompararVersao("1.2.3", "1.2.3");
+
+            resultado.Should().Be(0);
+        }
+
+        [Fact]
+        public void Deve_retornar_positivo_quando_a_maior_que_b()
+        {
+            var resultado = VersaoService.CompararVersao("3.0.0", "1.0.0");
+
+            resultado.Should().BePositive();
+        }
+
+        [Fact]
+        public void Deve_retornar_negativo_quando_a_tem_menos_partes()
+        {
+            var resultado = VersaoService.CompararVersao("1.0", "1.0.1");
+
+            resultado.Should().BeNegative();
+        }
+
+        [Fact]
+        public void Deve_retornar_positivo_quando_a_tem_mais_partes()
+        {
+            var resultado = VersaoService.CompararVersao("1.0.1", "1.0");
+
+            resultado.Should().BePositive();
+        }
+    }
+}

--- a/backend/tests/ProjectManagerWeb.Tests/Utils/LinuxShellProviderTests.cs
+++ b/backend/tests/ProjectManagerWeb.Tests/Utils/LinuxShellProviderTests.cs
@@ -1,0 +1,100 @@
+using ProjectManagerWeb.src.Utils;
+
+namespace ProjectManagerWeb.Tests.Utils;
+
+public class LinuxShellProviderTests
+{
+    public class ExtrairDiretorioDoComando
+    {
+        [Fact]
+        public void Deve_extrair_diretorio_quando_comando_inicia_com_cd()
+        {
+            var dir = LinuxShellProvider.ExtrairDiretorioDoComando("cd \"/home/user/projeto\"; npm start;");
+
+            dir.Should().Be("/home/user/projeto");
+        }
+
+        [Fact]
+        public void Deve_extrair_diretorio_quando_tem_export_antes()
+        {
+            var dir = LinuxShellProvider.ExtrairDiretorioDoComando("export PATH=\"$HOME/bin\"; cd \"/app/backend\"; dotnet run;");
+
+            dir.Should().Be("/app/backend");
+        }
+
+        [Fact]
+        public void Deve_retornar_null_quando_nao_tem_cd()
+        {
+            var dir = LinuxShellProvider.ExtrairDiretorioDoComando("npm start;");
+
+            dir.Should().BeNull();
+        }
+
+        [Fact]
+        public void Deve_extrair_apenas_primeiro_cd_quando_tem_varios()
+        {
+            var dir = LinuxShellProvider.ExtrairDiretorioDoComando("cd \"/primeiro\"; cd \"/segundo\";");
+
+            dir.Should().Be("/primeiro");
+        }
+
+        [Fact]
+        public void Deve_retornar_null_quando_cd_sem_aspas()
+        {
+            var dir = LinuxShellProvider.ExtrairDiretorioDoComando("cd /tmp; echo ok;");
+
+            dir.Should().BeNull();
+        }
+    }
+
+    public class RemoverMarcadorExit
+    {
+        [Fact]
+        public void Deve_remover_exit_do_final()
+        {
+            var resultado = LinuxShellProvider.RemoverMarcadorExit("cd \"/tmp\"; code .; Exit;");
+
+            resultado.Should().Be("cd \"/tmp\"; code .;");
+        }
+
+        [Fact]
+        public void Deve_remover_exit_case_insensitive()
+        {
+            var resultado = LinuxShellProvider.RemoverMarcadorExit("comando; EXIT;");
+
+            resultado.Should().Be("comando;");
+        }
+
+        [Fact]
+        public void Deve_retornar_mesmo_quando_nao_tem_exit()
+        {
+            var resultado = LinuxShellProvider.RemoverMarcadorExit("cd \"/tmp\"; npm start;");
+
+            resultado.Should().Be("cd \"/tmp\"; npm start;");
+        }
+
+        [Fact]
+        public void Deve_trim_trailing_spaces_antes_de_remover()
+        {
+            var resultado = LinuxShellProvider.RemoverMarcadorExit("comando; Exit;   ");
+
+            resultado.Should().Be("comando;");
+        }
+
+        [Fact]
+        public void Deve_retornar_vazio_quando_so_tem_exit()
+        {
+            var resultado = LinuxShellProvider.RemoverMarcadorExit("Exit;");
+
+            resultado.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void Nao_deve_remover_quando_exit_no_meio()
+        {
+            var resultado = LinuxShellProvider.RemoverMarcadorExit("Exit; cd /tmp;");
+
+            resultado.Should().Be("Exit; cd /tmp;");
+        }
+    }
+}

--- a/backend/tests/ProjectManagerWeb.Tests/Utils/TerminalEmulatorFactoryTests.cs
+++ b/backend/tests/ProjectManagerWeb.Tests/Utils/TerminalEmulatorFactoryTests.cs
@@ -1,0 +1,49 @@
+using ProjectManagerWeb.src.Utils.Terminais;
+
+namespace ProjectManagerWeb.Tests.Utils;
+
+public class TerminalEmulatorFactoryTests
+{
+    public class Criar
+    {
+        [Fact]
+        public void Deve_retornar_ptyxis_quando_terminal_null()
+        {
+            var terminal = TerminalEmulatorFactory.Criar(null);
+
+            terminal.Should().BeOfType<PtyxisTerminal>();
+        }
+
+        [Fact]
+        public void Deve_retornar_ptyxis_quando_terminal_vazio()
+        {
+            var terminal = TerminalEmulatorFactory.Criar(string.Empty);
+
+            terminal.Should().BeOfType<PtyxisTerminal>();
+        }
+
+        [Fact]
+        public void Deve_retornar_ptyxis_quando_valor_desconhecido()
+        {
+            var terminal = TerminalEmulatorFactory.Criar("konsole");
+
+            terminal.Should().BeOfType<PtyxisTerminal>();
+        }
+
+        [Fact]
+        public void Deve_retornar_ghostty_quando_terminal_eh_ghostty()
+        {
+            var terminal = TerminalEmulatorFactory.Criar("ghostty");
+
+            terminal.Should().BeOfType<GhosttyTerminal>();
+        }
+
+        [Fact]
+        public void Deve_ignorar_case_ao_comparar_nome()
+        {
+            var terminal = TerminalEmulatorFactory.Criar("GHOSTTY");
+
+            terminal.Should().BeOfType<GhosttyTerminal>();
+        }
+    }
+}

--- a/frontend/src/views/PastasView.vue
+++ b/frontend/src/views/PastasView.vue
@@ -949,13 +949,15 @@
     return menus;
   };
 
-  const executarComandoAvulso = (comando: string): void => {
+  const executarComandoAvulso = async (comando: string): Promise<void> => {
     try {
-      ComandosService.executarComandoAvulso({
+      await ComandosService.executarComandoAvulso({
         comando
       });
+      notificar('sucesso', 'Comando solicitado');
     } catch (error) {
       console.error('Falha ao executar o comando avulso: ', error);
+      notificar('erro', 'Falha ao executar o comando', String(error));
     }
   };
 

--- a/frontend/src/views/PastasView.vue
+++ b/frontend/src/views/PastasView.vue
@@ -765,20 +765,10 @@
 
     if (projetosComComandos.length === 0) return;
 
-    const payload: PayloadComando = {
-      diretorio: pastaSelecionada.value.diretorio,
-      repositorioId: pastaSelecionada.value.repositorioId || '',
-      projetos: projetosComComandos.map((p: any) => ({
-        identificador: p.identificador,
-        nome: p.nome,
-        comandos: p.comandosSelecionados || [],
-        identificadorRepositorioAgregado: p.identificadorRepositorioAgregado,
-        nomeRepositorio: p.nomeRepositorio
-      }))
-    };
+    const payload = construirPayloadSalvar(pastaSelecionada.value);
 
     try {
-      salvarAcoesSelecionadas(payload);
+      salvarMarcacoesPasta(pastaSelecionada.value, diretorioAcoes.value);
       notificar('sucesso', 'Comando solicitado');
 
       await carregandoAsync(async () => {
@@ -792,10 +782,32 @@
 
   const CHAVE_ACOES_SELECIONADAS = 'AcoesSelecionadas';
 
-  const salvarAcoesSelecionadas = (payload: PayloadComando): void => {
+  const construirPayloadSalvar = (pasta: IPasta): PayloadComando => {
+    const projetosComComandos = pasta.projetos.filter(
+      (p: any) => p.comandosSelecionados && p.comandosSelecionados.length > 0
+    );
+
+    return {
+      diretorio: pasta.diretorio,
+      repositorioId: pasta.repositorioId || '',
+      projetos: projetosComComandos.map((p: any) => ({
+        identificador: p.identificador,
+        nome: p.nome,
+        comandos: p.comandosSelecionados || [],
+        identificadorRepositorioAgregado: p.identificadorRepositorioAgregado,
+        nomeRepositorio: p.nomeRepositorio
+      }))
+    };
+  };
+
+  const salvarMarcacoesPasta = (
+    pasta: IPasta,
+    acoesDiretorio: string[] = []
+  ): void => {
+    const payload = construirPayloadSalvar(pasta);
     const payloadComDiretorioAcoes = {
       ...payload,
-      diretorioAcoes: diretorioAcoes.value
+      diretorioAcoes: acoesDiretorio
     };
 
     const salvarNoLocalStorage = (valor: any[]): void => {
@@ -809,9 +821,7 @@
       return;
     }
 
-    const indice = acoes.findIndex(
-      (a: any) => a.diretorio === payload.diretorio
-    );
+    const indice = acoes.findIndex((a: any) => a.diretorio === pasta.diretorio);
 
     indice === -1
       ? acoes.push(payloadComDiretorioAcoes)

--- a/frontend/src/views/PastasView.vue
+++ b/frontend/src/views/PastasView.vue
@@ -763,6 +763,8 @@
       (p: any) => p.comandosSelecionados && p.comandosSelecionados.length > 0
     );
 
+    salvarMarcacoesPasta(pastaSelecionada.value, diretorioAcoes.value);
+
     if (projetosComComandos.length === 0) return;
 
     const payload = construirPayloadSalvar(pastaSelecionada.value);


### PR DESCRIPTION
## O que mudou

### Testes unitários (106 testes)

| Servico | Testes | Cobertura |
|---------|--------|-----------|
| CloneService | 24 | Verificacao de branch, deteccao de branch principal, montagem de script, filtro de warnings |
| ComandoService | 12 | Abrir IDE, comando avulso, obter alvo do workspace |
| ConfiguracaoService | 17 | Perfis VSCode, pastas centralizadoras, diretorios ocultos |
| PastaJsonService | 9 | Upsert por diretorio, CRUD |
| RepositorioJsonService | 9 | URL duplicada, renomear perfil cascata, CRUD |
| IDEJsonService | 7 | Nome duplicado, CRUD |
| SiteIISJsonService | 7 | Nome duplicado, CRUD |
| VersaoService | 5 | Comparacao semantica de versoes |
| LinuxShellProvider | 11 | Extracao de diretorio do comando, remocao de marcador Exit |
| TerminalEmulatorFactory | 5 | Criacao do terminal correto |

### Refatoracoes para testabilidade

- `IGitCommandRunner` + `GitCommandRunner` — Process.Start do CloneService extraido para interface injetavel
- `IShellExecutor` + `ShellExecutor` — ShellExecute agora injetavel via interface
- `IIDEJsonService` — IDEJsonService agora tem interface para mock
- **JsonServices** (PastaJson, RepositorioJson, IDEJson, SiteIISJson) — FilePath virou instancia, construtor interno para testes com arquivo temporario
- **ConfiguracaoService** — mesmo padrao dos JsonServices
- Metodos internos expostos para teste: `ExtrairDiretorioDoComando`, `RemoverMarcadorExit`, `CompararVersao`, `ObterAlvoIDE`

### Terminais — correcao de bug

`PtyxisTerminal.cs` e `GhosttyTerminal.cs`: o `execBash` usava aspas duplas literais dentro do `-c "..."` do bash, quebrando o comando. O terminal abria mas o `cd` nunca executava — apos Ctrl+C o terminal voltava ao `$HOME`. Corrigido para aspas simples.

### CI/CD

- `ci.yml` — job `test-backend` roda 106 testes em todo PR para `develop`/`main`
- `ci.yml` — geracao de relatorio de cobertura com ReportGenerator + upload como artefato
- `ci.yml` — se testes falharem, merge bloqueado (configurar branch protection no GitHub)
- `Coverage.runsettings` — exclusao de Controllers, DTOs, IISService, etc. da cobertura
- `test-coverage.sh` — script local para testes + relatorio HTML
- AGENTS.md — comandos de teste documentados

### Versao

`VersaoService.cs`: agora usa regex `\d+\.\d+\.\d+` para extrair a versao do `AssemblyInformationalVersionAttribute`. Antes incluia o hash do commit (ex: `1.0.8+gdf8f7a8`), agora mostra so `1.0.8`.

### Marcacoes na UI

`PastasView.vue`: logica de salvar/restaurar marcacoes extraida para funcoes reutilizaveis (`construirPayloadSalvar`, `salvarMarcacoesPasta`). `executarComandoAvulso` agora e async e mostra notificacoes de sucesso/erro. Salvamento agora acontece antes do try, garantindo que mesmo que o comando falhe, as selecoes sao persistidas.

### Novos arquivos

| Arquivo | Descricao |
|---------|-----------|
| `backend/src/Utils/IShellExecutor.cs` | Interface para mockar ShellExecute |
| `backend/src/Utils/ShellExecutor.cs` | Implementacao real delegando para ShellExecute |
| `backend/src/Services/IIDEJsonService.cs` | Interface para mockar IDEJsonService |
| `backend/src/Services/IGitCommandRunner.cs` | Interface para mockar execucao de git |
| `backend/src/Services/GitCommandRunner.cs` | Implementacao real com Process.Start |
| `backend/Coverage.runsettings` | Config de cobertura com exclusoes |
| `backend/test-coverage.sh` | Script: testes + cobertura + relatorio HTML |
| `.opencode/agents/testador.md` | Skill especialista em testes xUnit + NSubstitute + FluentAssertions |
| `backend/tests/ProjectManagerWeb.Tests/` | Projeto de testes com 10 arquivos de teste |

## Como testar

```bash
# Rodar todos os testes
dotnet test backend/tests/ProjectManagerWeb.Tests/ProjectManagerWeb.Tests.csproj

# Testes + relatorio de cobertura HTML
bash backend/test-coverage.sh
```
