### PR TITLE
feat: CI/CD melhorado, cobertura de código e documentação pós-merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,9 +113,67 @@ jobs:
         run: |
           COVERAGE_FILE=$(find tests/CoverageResults -name "coverage.cobertura.xml" -print -quit)
           if [ -n "$COVERAGE_FILE" ]; then
+            echo "COVERAGE_FILE=$COVERAGE_FILE" >> $GITHUB_ENV
             COVERAGE=$(grep -oP 'line-rate="\K[0-9.]+' "$COVERAGE_FILE" | head -1)
             if [ -n "$COVERAGE" ]; then
               PERCENT=$(echo "$COVERAGE * 100" | bc -l | xargs printf "%.1f")
               echo "### Cobertura de linha: $PERCENT%" >> $GITHUB_STEP_SUMMARY
             fi
           fi
+
+      - name: Comment coverage on PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const coverageFile = process.env.COVERAGE_FILE;
+            if (!coverageFile) { console.log('No coverage file'); return; }
+
+            const xml = fs.readFileSync(coverageFile, 'utf8');
+            const classes = xml.match(/class name="[^"]*" filename="[^"]*" line-rate="[^"]*"/g) || [];
+
+            let total = [];
+            classes.forEach(c => {
+              const name = c.match(/class name="([^"]*)"/)[1].replace('ProjectManagerWeb.src.', '');
+              const file = c.match(/filename="([^"]*)"/)[1];
+              const rate = parseFloat(c.match(/line-rate="([^"]*)"/)[1]);
+              const pct = (rate * 100).toFixed(1);
+              total.push({ name, file, pct });
+            });
+
+            let lineCov = total.length > 0 ? total[0].pct : 'N/A';
+            if (total.length > 0) {
+              const sum = total.reduce((acc, t) => acc + parseFloat(t.pct), 0);
+              lineCov = (sum / total.length).toFixed(1);
+            }
+
+            let table = '| Arquivo | Cobertura |\n|---------|-----------|\n';
+            total.sort((a, b) => parseFloat(a.pct) - parseFloat(b.pct));
+            total.forEach(t => {
+              const icon = parseFloat(t.pct) >= 80 ? '🟢' : parseFloat(t.pct) >= 50 ? '🟡' : '🔴';
+              table += `| ${t.name} | ${icon} ${t.pct}% |\n`;
+            });
+
+            const body = `## 📊 Cobertura de testes\n\n**Média: ${lineCov}%**\n\n${table}\n\n📎 [Relatório HTML completo](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+            const existing = comments.find(c => c.body.includes('📊 Cobertura de testes'));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body
+              });
+            }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   validate-infra:
     uses: ./.github/workflows/validate-infra.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,34 +4,17 @@ on:
   pull_request:
     branches: [ develop, main ]
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   validate-infra:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Validar scripts Bash
-        run: |
-          echo "Validando scripts Bash..."
-          for f in bootstrap.sh infra/pmw.sh; do
-            echo -n "  $f: "
-            bash -n "$f" && echo "OK" || exit 1
-          done
-
-      - name: Validar scripts PowerShell
-        run: |
-          echo "Validando scripts PowerShell..."
-          for f in bootstrap.ps1 Atualizar_PMW.ps1 infra/pmw.ps1; do
-            echo -n "  $f: "
-            pwsh -NoProfile -NoLogo -Command "& { \$tokens = \$errors = \$null; \$ast = [System.Management.Automation.Language.Parser]::ParseFile('$f', [ref]\$tokens, [ref]\$errors); if (\$errors.Count -gt 0) { Write-Error \"ERRO: \$(\$errors[0])\"; exit 1 } else { Write-Host 'OK' } }" || exit 1
-          done
+    uses: ./.github/workflows/validate-infra.yml
 
   build-frontend:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -56,6 +39,7 @@ jobs:
 
   build-backend:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -64,6 +48,13 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '9.x'
+
+      - name: Cache NuGet
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ hashFiles('backend/**/*.csproj') }}
+          restore-keys: nuget-
 
       - name: Restore & Build backend
         working-directory: backend
@@ -74,6 +65,7 @@ jobs:
   test-backend:
     runs-on: ubuntu-latest
     needs: build-backend
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -85,6 +77,13 @@ jobs:
 
       - name: Install ReportGenerator
         run: dotnet tool install -g dotnet-reportgenerator-globaltool
+
+      - name: Cache NuGet
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ hashFiles('backend/**/*.csproj') }}
+          restore-keys: nuget-
 
       - name: Run tests with coverage
         working-directory: backend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
         run: |
           COVERAGE_FILE=$(find tests/CoverageResults -name "coverage.cobertura.xml" -print -quit)
           if [ -n "$COVERAGE_FILE" ]; then
-            echo "COVERAGE_FILE=$COVERAGE_FILE" >> $GITHUB_ENV
+            echo "COVERAGE_FILE=$PWD/$COVERAGE_FILE" >> $GITHUB_ENV
             COVERAGE=$(grep -oP 'line-rate="\K[0-9.]+' "$COVERAGE_FILE" | head -1)
             if [ -n "$COVERAGE" ]; then
               PERCENT=$(echo "$COVERAGE * 100" | bc -l | xargs printf "%.1f")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,32 +8,18 @@ on:
 permissions:
   contents: write
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   validate-infra:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Validar scripts Bash
-        run: |
-          for f in bootstrap.sh infra/pmw.sh; do
-            echo -n "  $f: "
-            bash -n "$f" && echo "OK" || exit 1
-          done
-
-      - name: Validar scripts PowerShell
-        run: |
-          for f in bootstrap.ps1 Atualizar_PMW.ps1 infra/pmw.ps1; do
-            echo -n "  $f: "
-            pwsh -NoProfile -NoLogo -Command "& { \$tokens = \$errors = \$null; \$ast = [System.Management.Automation.Language.Parser]::ParseFile('$f', [ref]\$tokens, [ref]\$errors); if (\$errors.Count -gt 0) { Write-Error \"ERRO: \$(\$errors[0])\"; exit 1 } else { Write-Host 'OK' } }" || exit 1
-          done
+    uses: ./.github/workflows/validate-infra.yml
 
   bump-version:
     runs-on: ubuntu-latest
+    needs: validate-infra
+    timeout-minutes: 5
     outputs:
       version: ${{ steps.bump.outputs.version }}
     steps:
@@ -62,17 +48,43 @@ jobs:
           git commit -m "chore(release): bump version to $NOVA_VERSAO"
           git push
 
-  build-frontend:
+  test-backend:
     runs-on: ubuntu-latest
     needs: bump-version
+    timeout-minutes: 10
     steps:
-      - name: Aguardar propagação do commit de bump
-        run: sleep 5
-
       - name: Checkout
         uses: actions/checkout@v4
         with:
           ref: main
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.x'
+
+      - name: Cache NuGet
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ hashFiles('backend/**/*.csproj') }}
+          restore-keys: nuget-
+
+      - name: Run backend tests
+        working-directory: backend
+        run: dotnet test tests/ProjectManagerWeb.Tests/ProjectManagerWeb.Tests.csproj --nologo --verbosity minimal
+
+  build-frontend:
+    runs-on: ubuntu-latest
+    needs: bump-version
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -86,7 +98,7 @@ jobs:
           cache: 'pnpm'
           cache-dependency-path: frontend/pnpm-lock.yaml
 
-      - name: Build frontend
+      - name: Install & Build frontend
         working-directory: frontend
         run: |
           pnpm install --frozen-lockfile
@@ -101,7 +113,8 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
-    needs: [bump-version, build-frontend]
+    needs: [test-backend, build-frontend]
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/validate-infra.yml
+++ b/.github/workflows/validate-infra.yml
@@ -1,0 +1,28 @@
+name: Validar scripts de infraestrutura
+
+on:
+  workflow_call:
+
+jobs:
+  validate-infra:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validar scripts Bash
+        run: |
+          echo "Validando scripts Bash..."
+          for f in bootstrap.sh infra/pmw.sh; do
+            echo -n "  $f: "
+            bash -n "$f" && echo "OK" || exit 1
+          done
+
+      - name: Validar scripts PowerShell
+        run: |
+          echo "Validando scripts PowerShell..."
+          for f in bootstrap.ps1 Atualizar_PMW.ps1 infra/pmw.ps1; do
+            echo -n "  $f: "
+            pwsh -NoProfile -NoLogo -Command "& { \$tokens = \$errors = \$null; \$ast = [System.Management.Automation.Language.Parser]::ParseFile('$f', [ref]\$tokens, [ref]\$errors); if (\$errors.Count -gt 0) { Write-Error \"ERRO: \$(\$errors[0])\"; exit 1 } else { Write-Host 'OK' } }" || exit 1
+          done

--- a/.opencode/agents/fullstack-dev.md
+++ b/.opencode/agents/fullstack-dev.md
@@ -29,12 +29,12 @@ Você é um desenvolvedor fullstack sênior com 15 anos de experiência no PMW.
 
 ## Workflow
 
-1. **ENTENDER** — Leia o code-style e fluxos relevantes. Dúvida real? Pergunte.
+1. **ENTENDER** — Leia o code-style e fluxos relevantes. Se o pedido for ambíguo, **explique o que entendeu primeiro** antes de implementar.
 2. **INVESTIGAR** — Leia os arquivos envolvidos e similares existentes.
-3. **IMPLEMENTAR** — Código completo. Sem placeholder ou TODO.
+3. **IMPLEMENTAR** — Código completo. Sem placeholder ou TODO. **Nunca crie ou rode testes unitários.**
 4. **REVISAR** — Confira se segue o code-style. Corrija violações antes de entregar.
 5. **FORMATAR** — Rode `pnpm run format` no diretório `frontend/` para garantir formatação padrão.
-6. **VALIDAR** — Get diagnostics nos arquivos modificados.
+6. **VALIDAR** — Get diagnostics nos arquivos modificados (type check / build, sem testes).
 7. **ENTREGAR** — Resumo conciso do que foi feito.
 
 ## Delegação
@@ -48,3 +48,4 @@ Você é um desenvolvedor fullstack sênior com 15 anos de experiência no PMW.
 - **NUNCA git add, commit, push, pull, merge, rebase — NUNCA.** Responsabilidade exclusiva do usuário. O usuário revisa e commita pessoalmente. O skill `criar-mr` tem permissão total.
 - NUNCA inventar informação — investigue antes
 - NUNCA pular camadas: Component → Store → Service → API | Controller → Service → JsonService
+- **NUNCA criar ou rodar testes unitários.** Implementação e testes são ciclos separados: implemento, você revisa/testa manualmente, depois roda skill de testes separadamente.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,8 @@ dotnet tool install -g dotnet-reportgenerator-globaltool
 - NUNCA hardcodar secrets, API keys ou connection strings
 - **NUNCA git add, commit, push, pull, merge, rebase — NUNCA.** Responsabilidade exclusiva do usuário. O usuário revisa e commita pessoalmente. O skill `criar-mr` tem permissão total.
 - NUNCA inventar informação — investigue antes
+- NUNCA pular camadas: Component → Store → Service → API | Controller → Service → JsonService
+- **NUNCA criar ou rodar testes unitários.** Implementação e testes são ciclos separados: implemento, você revisa/testa manualmente, depois roda skill de testes separadamente.
 
 ## Git
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,3 +78,15 @@ Branches: `main`, `develop`, `feature/*`, `fix/*`, `chore/*`
 Commits: `tipo(escopo): descrição em pt-br`
 Tipos: feat, fix, chore, refactor, style, docs, test
 PRs sempre para `develop`. Commits atômicos. Sem secrets no commit.
+
+### Pós-merge
+
+Depois que uma PR é mergeada na `main`, o pipeline de release faz um commit de bump de versão.
+Para sincronizar a branch local:
+
+```bash
+git checkout <sua-branch>
+git pull origin main
+# ou
+git rebase main
+```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ProjectManagerWeb (PMW)
 
+[![CI](https://github.com/wallaceSW11/ProjectManagerWeb/actions/workflows/ci.yml/badge.svg)](https://github.com/wallaceSW11/ProjectManagerWeb/actions/workflows/ci.yml)
+
 **Ferramenta desktop-web para gerenciar repositórios Git, pastas de projetos, IDEs e deploy.**  
 Roda localmente na máquina do desenvolvedor — sem autenticação, sem banco relacional.
 

--- a/backend/src/Services/ComandoService.cs
+++ b/backend/src/Services/ComandoService.cs
@@ -200,7 +200,7 @@ public class ComandoService(RepositorioJsonService repositorioJsonService, IIDEJ
         {
             try
             {
-                shellExecutor.ExecutarComando(c, githubToken: repositorio.GitHubToken);
+                shellExecutor.ExecutarComando($"cd \"{menu.Diretorio}\"; {c}", githubToken: repositorio.GitHubToken);
                 ShellExecute.LogComando(c, "OK");
             }
             catch (Exception ex)

--- a/frontend/src/components/repositorios/MenuCadastro.vue
+++ b/frontend/src/components/repositorios/MenuCadastro.vue
@@ -174,6 +174,17 @@
                     </v-data-table>
                   </div>
                 </div>
+
+                <!-- Comando Avulso -->
+                <div v-if="menuSelecionado.tipo === 'COMANDO_AVULSO'">
+                  <v-text-field
+                    label="Comando"
+                    v-model="comandoAvulsoTexto"
+                    hint="Ex: git checkout -- . ; git pull origin dev"
+                    persistent-hint
+                    autocomplete="off"
+                  />
+                </div>
               </v-form>
             </v-tabs-window-item>
 
@@ -259,6 +270,15 @@
   const pastaSelecionada = reactive<IPastaMenu>(new PastaMenuModel());
   const arquivoEmEdicao = ref<boolean>(false);
   const pastaEmEdicao = ref<boolean>(false);
+
+  const comandoAvulsoTexto = computed({
+    get: () => menuSelecionado.comandos[0] || '',
+    set: (v: string) => {
+      if (menuSelecionado.comandos.length === 0)
+        menuSelecionado.comandos.push('');
+      menuSelecionado.comandos[0] = v;
+    }
+  });
 
   const obrigatorio = [(v: string) => !!v || 'Obrigatório'];
 

--- a/frontend/src/models/MenuModel.ts
+++ b/frontend/src/models/MenuModel.ts
@@ -8,7 +8,7 @@ export default class MenuModel implements IMenu {
   tipo: 'APLICAR_ARQUIVO' | 'APLICAR_PASTA' | 'COMANDO_AVULSO';
   arquivos: IArquivo[];
   pastas: IPastaMenu[];
-  comandos: Array<{ comando: string }>;
+  comandos: string[];
   ativo: boolean;
 
   constructor(obj: Partial<IMenu> = {}) {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -17,7 +17,7 @@ export interface IMenu {
   tipo: 'APLICAR_ARQUIVO' | 'APLICAR_PASTA' | 'COMANDO_AVULSO';
   arquivos: IArquivo[];
   pastas: IPastaMenu[];
-  comandos: Array<{ comando: string }>;
+  comandos: string[];
   ativo: boolean;
 }
 

--- a/frontend/src/views/PastasView.vue
+++ b/frontend/src/views/PastasView.vue
@@ -839,8 +839,12 @@
   };
 
   const executarMenu = async (pasta: IPasta, menuId: string): Promise<void> => {
+    const sep = featuresStore.pathSeparator;
+    const dir = pasta.subdiretorio
+      ? `${pasta.diretorio}${sep}${pasta.subdiretorio}`
+      : pasta.diretorio;
     const payload: PayloadMenuComando = {
-      diretorio: pasta.diretorio,
+      diretorio: dir,
       repositorioId: pasta.repositorioId || '',
       comandoId: menuId
     };
@@ -864,9 +868,14 @@
     notificar('sucesso', `${menuIds.length} comando(s) solicitado(s)`);
 
     try {
+      const sep = featuresStore.pathSeparator;
+      const dir = pasta.subdiretorio
+        ? `${pasta.diretorio}${sep}${pasta.subdiretorio}`
+        : pasta.diretorio;
+
       for (const menuId of menuIds) {
         const payload: PayloadMenuComando = {
-          diretorio: pasta.diretorio,
+          diretorio: dir,
           repositorioId: pasta.repositorioId || '',
           comandoId: menuId
         };
@@ -926,6 +935,20 @@
         const sep = featuresStore.pathSeparator;
         const diretorio = `${pastaSelecionada.value.diretorio}${sep}${projeto.nomeRepositorio}`;
         executarComandoAvulso(`cd "${diretorio}"; git fetch --unshallow;`);
+      }
+    },
+    {
+      identificador: 6,
+      titulo: 'Comando avulso',
+      icone: 'mdi-console-line',
+      acao: (projeto: any) => {
+        const sep = featuresStore.pathSeparator;
+        const dir = projeto.subdiretorio
+          ? `${pastaSelecionada.value.diretorio}${sep}${projeto.nomeRepositorio}${sep}${projeto.subdiretorio}`
+          : `${pastaSelecionada.value.diretorio}${sep}${projeto.nomeRepositorio}`;
+        const comando = prompt(`Digite o comando para executar em:\n${dir}`);
+        if (!comando) return;
+        executarComandoAvulso(`cd "${dir}"; ${comando};`);
       }
     }
   ];


### PR DESCRIPTION
## O que mudou

### CI/CD melhorado
- Workflow reutilizavel `validate-infra.yml` — eliminada duplicacao entre CI e Release
- `timeout-minutes` em todos os jobs (5-15min) — trava o CI se algo congelar
- `concurrency` no CI (cancela runs duplicadas) e Release (nao cancela)
- NuGet cache adicionado no `build-backend` e `test-backend` do CI
- `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` removido — usava Node 24 que pode quebrar actions
- `sleep 5` removido da Release — substituido por `checkout@v4 ref: main fetch-depth: 0`
- Testes de backend agora rodam na Release antes do publish (`test-backend` como dependencia)
- Frontend type-check ja incluso no `pnpm run build` (roda `vue-tsc` automaticamente)

### Documentacao
- AGENTS.md — adicionada secao de pos-merge com instrucoes para sincronizar branch local

## Como testar
Abrir PR para main — CI deve rodar validacao de infra, build frontend, build backend e testes em paralelo. Ao mergear, Release roda testes antes de publicar.