### PR TITLE
feat: ajustar skip-worktree, testes unitários e persistência de aba no executar

### DIFF
--- a/backend/src/Services/ComandoService.cs
+++ b/backend/src/Services/ComandoService.cs
@@ -170,7 +170,7 @@ public class ComandoService(RepositorioJsonService repositorioJsonService, IIDEJ
                 ShellExecute.LogComando($"File.Copy \"{a.Arquivo}\" -> \"{caminhoArquivoDestino}\"", "OK");
 
                 if (a.IgnorarGit)
-                    IgnorarArquivoNoGit(caminhoArquivoDestino);
+                    AplicarSkipWorktree(caminhoArquivoDestino);
             }
             catch (Exception ex)
             {
@@ -223,7 +223,7 @@ public class ComandoService(RepositorioJsonService repositorioJsonService, IIDEJ
             CopiarDiretorioRecursivo(subDir, Path.Combine(destino, Path.GetFileName(subDir)));
     }
 
-    private static void IgnorarArquivoNoGit(string caminhoArquivo)
+    private static void AplicarSkipWorktree(string caminhoArquivo)
     {
         try
         {
@@ -246,15 +246,14 @@ public class ComandoService(RepositorioJsonService repositorioJsonService, IIDEJ
 
             if (string.IsNullOrEmpty(raizGit) || processo.ExitCode != 0) return;
 
-            var caminhoRelativo = Path.GetRelativePath(raizGit, caminhoArquivo).Replace('\\', '/');
+            var caminhoRelativo = Path.GetRelativePath(raizGit, caminhoArquivo)
+                .Replace('\\', '/')
+                .TrimEnd('/');
 
-            var gitIgnorePath = Path.Combine(raizGit, ".gitignore");
-
-            var estaRastreado = false;
             var verificaRastreado = new ProcessStartInfo
             {
                 FileName = "git",
-                Arguments = $"-C \"{raizGit}\" ls-files --error-unmatch \"{caminhoRelativo}\"",
+                Arguments = $"-C \"{raizGit}\" ls-files \"{caminhoRelativo}\"",
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 UseShellExecute = false,
@@ -262,22 +261,31 @@ public class ComandoService(RepositorioJsonService repositorioJsonService, IIDEJ
             };
 
             using var procVerifica = Process.Start(verificaRastreado);
-            if (procVerifica is not null)
-            {
-                procVerifica.WaitForExit();
-                estaRastreado = procVerifica.ExitCode == 0;
-            }
+            if (procVerifica is null) return;
 
-            if (estaRastreado)
+            var saida = procVerifica.StandardOutput.ReadToEnd().Trim();
+            procVerifica.WaitForExit();
+
+            if (string.IsNullOrEmpty(saida)) return;
+
+            var skipPsi = new ProcessStartInfo
             {
-                var comando = $"cd \"{raizGit}\"; git update-index --assume-unchanged \"{caminhoRelativo}\"; Exit;";
-                ShellExecute.ExecutarComando(comando);
-            }
-            else
-            {
-                var entrada = $"{caminhoRelativo}{Environment.NewLine}";
-                File.AppendAllText(gitIgnorePath, entrada);
-            }
+                FileName = "git",
+                Arguments = $"-C \"{raizGit}\" update-index --skip-worktree \"{caminhoRelativo}\"",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            using var procSkip = Process.Start(skipPsi);
+            if (procSkip is null) return;
+
+            var erroSkip = procSkip.StandardError.ReadToEnd().Trim();
+            procSkip.WaitForExit();
+
+            if (procSkip.ExitCode != 0)
+                ShellExecute.LogComando($"skip-worktree falhou ({procSkip.ExitCode}) para {caminhoRelativo}: {erroSkip}", "ERRO");
         }
         catch
         {

--- a/backend/src/Services/RepositorioJsonService.cs
+++ b/backend/src/Services/RepositorioJsonService.cs
@@ -40,7 +40,7 @@ namespace ProjectManagerWeb.src.Services
             return [.. repositorios.OrderBy(r => r.Indice)];
         }
 
-        public async Task<RepositorioRequestDTO?> GetByIdAsync(Guid identificador)
+        public virtual async Task<RepositorioRequestDTO?> GetByIdAsync(Guid identificador)
         {
             var repositorios = await LerListaDoArquivoAsync();
             return repositorios.FirstOrDefault(r => r.Identificador == identificador);

--- a/backend/tests/ProjectManagerWeb.Tests/Services/ComandoServiceTests.cs
+++ b/backend/tests/ProjectManagerWeb.Tests/Services/ComandoServiceTests.cs
@@ -160,4 +160,354 @@ public class ComandoServiceTests
             resultado.Should().BeFalse();
         }
     }
+
+    public class ExecutarComandoMenu : ComandoServiceTests
+    {
+        private readonly Guid _repositorioId = Guid.NewGuid();
+        private readonly Guid _comandoId = Guid.NewGuid();
+        private readonly string _destinoDir = Path.Combine(Path.GetTempPath(), "pmw-test-menu-" + Guid.NewGuid());
+
+        private RepositorioRequestDTO CriarRepositorio(List<MenuDTO> menus) =>
+            new(_repositorioId, "https://github.com/test/repo", "test-repo",
+                "Test Repo", null, "main", new List<ProjetoDTO>(),
+                null, menus, null);
+
+        private MenuRequestDTO CriarMenu() =>
+            new(_repositorioId, _comandoId, _destinoDir);
+
+        [Fact]
+        public async Task Deve_lancar_key_not_found_quando_repositorio_nao_encontrado()
+        {
+            _repositorioJson.GetByIdAsync(Arg.Any<Guid>()).Returns((RepositorioRequestDTO?)null);
+
+            var act = () => _sut.ExecutarComandoMenu(CriarMenu());
+
+            await act.Should().ThrowAsync<KeyNotFoundException>().WithMessage("Repositório não encontrado");
+        }
+
+        [Fact]
+        public async Task Deve_lancar_key_not_found_quando_comando_nao_encontrado_no_repositorio()
+        {
+            var repo = CriarRepositorio(new List<MenuDTO>());
+            _repositorioJson.GetByIdAsync(_repositorioId).Returns(repo);
+
+            var act = () => _sut.ExecutarComandoMenu(CriarMenu());
+
+            await act.Should().ThrowAsync<KeyNotFoundException>().WithMessage("Comando não encontrado");
+        }
+
+        [Fact]
+        public async Task Deve_executar_comandos_via_shell_quando_menu_possui_comandos()
+        {
+            var comandos = new List<string> { "echo hello" };
+            var menuDto = new MenuDTO(_comandoId, "Test", "comando", null, null, comandos);
+            var repo = CriarRepositorio(new List<MenuDTO> { menuDto });
+            _repositorioJson.GetByIdAsync(_repositorioId).Returns(repo);
+
+            var resultado = await _sut.ExecutarComandoMenu(CriarMenu());
+
+            resultado.Should().BeTrue();
+            _shell.Received(1).ExecutarComando(
+                Arg.Is<string>(c => c.Contains("echo hello")),
+                Arg.Any<string?>(),
+                Arg.Any<string?>());
+        }
+
+        [Fact]
+        public async Task Deve_passar_github_token_para_comandos_do_shell_quando_repositorio_possui_token()
+        {
+            var token = "ghp_token123";
+            var comandos = new List<string> { "git pull" };
+            var menuDto = new MenuDTO(_comandoId, "Test", "comando", null, null, comandos);
+            var repo = CriarRepositorio(new List<MenuDTO> { menuDto }) with { GitHubToken = token };
+            _repositorioJson.GetByIdAsync(_repositorioId).Returns(repo);
+
+            var resultado = await _sut.ExecutarComandoMenu(CriarMenu());
+
+            resultado.Should().BeTrue();
+            _shell.Received(1).ExecutarComando(
+                Arg.Is<string>(c => c.Contains("git pull")),
+                Arg.Any<string?>(),
+                Arg.Is<string?>(t => t == token));
+        }
+
+        [Fact]
+        public async Task Deve_copiar_arquivo_para_destino_quando_ignorar_git_true_e_arquivo_origem_existe()
+        {
+            var dirTeste = Path.Combine(Path.GetTempPath(), "pmw-test-menu-src-" + Guid.NewGuid());
+            Directory.CreateDirectory(dirTeste);
+            var arquivoOrigem = Path.Combine(dirTeste, "web.config");
+            File.WriteAllText(arquivoOrigem, "<configuration></configuration>");
+
+            try
+            {
+                var arquivos = new List<ArquivosDTO>
+                {
+                    new(arquivoOrigem, "subpasta", true)
+                };
+                var menuDto = new MenuDTO(_comandoId, "Test", "arquivo", arquivos, null, null);
+                var repo = CriarRepositorio(new List<MenuDTO> { menuDto });
+                _repositorioJson.GetByIdAsync(_repositorioId).Returns(repo);
+
+                var resultado = await _sut.ExecutarComandoMenu(CriarMenu());
+
+                resultado.Should().BeTrue();
+
+                var destinoEsperado = Path.Combine(_destinoDir, "subpasta", "web.config");
+                File.Exists(destinoEsperado).Should().BeTrue();
+                var conteudoDestino = await File.ReadAllTextAsync(destinoEsperado);
+                conteudoDestino.Should().Be("<configuration></configuration>");
+            }
+            finally
+            {
+                if (Directory.Exists(dirTeste))
+                    Directory.Delete(dirTeste, true);
+            }
+        }
+
+        [Fact]
+        public async Task Deve_copiar_arquivo_para_destino_quando_ignorar_git_false_e_arquivo_origem_existe()
+        {
+            var dirTeste = Path.Combine(Path.GetTempPath(), "pmw-test-menu-src-" + Guid.NewGuid());
+            Directory.CreateDirectory(dirTeste);
+            var arquivoOrigem = Path.Combine(dirTeste, "appsettings.json");
+            File.WriteAllText(arquivoOrigem, "{}");
+
+            try
+            {
+                var arquivos = new List<ArquivosDTO>
+                {
+                    new(arquivoOrigem, "config", false)
+                };
+                var menuDto = new MenuDTO(_comandoId, "Test", "arquivo", arquivos, null, null);
+                var repo = CriarRepositorio(new List<MenuDTO> { menuDto });
+                _repositorioJson.GetByIdAsync(_repositorioId).Returns(repo);
+
+                var resultado = await _sut.ExecutarComandoMenu(CriarMenu());
+
+                resultado.Should().BeTrue();
+
+                var destinoEsperado = Path.Combine(_destinoDir, "config", "appsettings.json");
+                File.Exists(destinoEsperado).Should().BeTrue();
+            }
+            finally
+            {
+                if (Directory.Exists(dirTeste))
+                    Directory.Delete(dirTeste, true);
+            }
+        }
+
+        [Fact]
+        public async Task Deve_usar_destino_como_nome_completo_quando_destino_tem_extensao()
+        {
+            var dirTeste = Path.Combine(Path.GetTempPath(), "pmw-test-menu-src-" + Guid.NewGuid());
+            Directory.CreateDirectory(dirTeste);
+            var arquivoOrigem = Path.Combine(dirTeste, "original.txt");
+            File.WriteAllText(arquivoOrigem, "conteudo");
+
+            try
+            {
+                var arquivos = new List<ArquivosDTO>
+                {
+                    new(arquivoOrigem, "renomeado.txt", false)
+                };
+                var menuDto = new MenuDTO(_comandoId, "Test", "arquivo", arquivos, null, null);
+                var repo = CriarRepositorio(new List<MenuDTO> { menuDto });
+                _repositorioJson.GetByIdAsync(_repositorioId).Returns(repo);
+
+                var resultado = await _sut.ExecutarComandoMenu(CriarMenu());
+
+                resultado.Should().BeTrue();
+
+                var destinoEsperado = Path.Combine(_destinoDir, "renomeado.txt");
+                File.Exists(destinoEsperado).Should().BeTrue();
+            }
+            finally
+            {
+                if (Directory.Exists(dirTeste))
+                    Directory.Delete(dirTeste, true);
+            }
+        }
+
+        [Fact]
+        public async Task Nao_deve_lancar_excecao_quando_arquivo_origem_inexistente()
+        {
+            var arquivos = new List<ArquivosDTO>
+            {
+                new("/caminho/inexistente/arquivo.exe", "sub", false)
+            };
+            var menuDto = new MenuDTO(_comandoId, "Test", "arquivo", arquivos, null, null);
+            var repo = CriarRepositorio(new List<MenuDTO> { menuDto });
+            _repositorioJson.GetByIdAsync(_repositorioId).Returns(repo);
+
+            var resultado = await _sut.ExecutarComandoMenu(CriarMenu());
+
+            resultado.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task Deve_criar_diretorio_destino_quando_nao_existe()
+        {
+            var dirTeste = Path.Combine(Path.GetTempPath(), "pmw-test-menu-src-" + Guid.NewGuid());
+            Directory.CreateDirectory(dirTeste);
+            var arquivoOrigem = Path.Combine(dirTeste, "index.html");
+            File.WriteAllText(arquivoOrigem, "<html></html>");
+
+            var destinoSubdir = "nova_pasta_criada";
+
+            try
+            {
+                var arquivos = new List<ArquivosDTO>
+                {
+                    new(arquivoOrigem, destinoSubdir, false)
+                };
+                var menuDto = new MenuDTO(_comandoId, "Test", "arquivo", arquivos, null, null);
+                var repo = CriarRepositorio(new List<MenuDTO> { menuDto });
+                _repositorioJson.GetByIdAsync(_repositorioId).Returns(repo);
+
+                var resultado = await _sut.ExecutarComandoMenu(CriarMenu());
+
+                resultado.Should().BeTrue();
+
+                var destinoEsperado = Path.Combine(_destinoDir, destinoSubdir, "index.html");
+                File.Exists(destinoEsperado).Should().BeTrue();
+            }
+            finally
+            {
+                if (Directory.Exists(dirTeste))
+                    Directory.Delete(dirTeste, true);
+            }
+        }
+
+        [Fact]
+        public async Task Deve_copiar_pasta_recursivamente_quando_origem_existe()
+        {
+            var dirOrigem = Path.Combine(Path.GetTempPath(), "pmw-test-pasta-src-" + Guid.NewGuid());
+            var subDir = Path.Combine(dirOrigem, "sub");
+            Directory.CreateDirectory(subDir);
+            File.WriteAllText(Path.Combine(dirOrigem, "root.txt"), "root");
+            File.WriteAllText(Path.Combine(subDir, "sub.txt"), "sub");
+
+            try
+            {
+                var pastas = new List<PastaDTO>
+                {
+                    new(dirOrigem, "destino_pasta")
+                };
+                var menuDto = new MenuDTO(_comandoId, "Test", "pasta", null, pastas, null);
+                var repo = CriarRepositorio(new List<MenuDTO> { menuDto });
+                _repositorioJson.GetByIdAsync(_repositorioId).Returns(repo);
+
+                var resultado = await _sut.ExecutarComandoMenu(CriarMenu());
+
+                resultado.Should().BeTrue();
+
+                var dirDestino = Path.Combine(_destinoDir, "destino_pasta");
+                Directory.Exists(dirDestino).Should().BeTrue();
+                File.Exists(Path.Combine(dirDestino, "root.txt")).Should().BeTrue();
+                File.Exists(Path.Combine(dirDestino, "sub", "sub.txt")).Should().BeTrue();
+            }
+            finally
+            {
+                if (Directory.Exists(dirOrigem))
+                    Directory.Delete(dirOrigem, true);
+            }
+        }
+
+        [Fact]
+        public async Task Nao_deve_lancar_excecao_quando_pasta_origem_inexistente()
+        {
+            var pastas = new List<PastaDTO>
+            {
+                new("/caminho/inexistente/pasta", "destino")
+            };
+            var menuDto = new MenuDTO(_comandoId, "Test", "pasta", null, pastas, null);
+            var repo = CriarRepositorio(new List<MenuDTO> { menuDto });
+            _repositorioJson.GetByIdAsync(_repositorioId).Returns(repo);
+
+            var resultado = await _sut.ExecutarComandoMenu(CriarMenu());
+
+            resultado.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task Deve_executar_todos_os_tipos_quando_menu_completo()
+        {
+            var dirSrc = Path.Combine(Path.GetTempPath(), "pmw-test-full-src-" + Guid.NewGuid());
+            Directory.CreateDirectory(dirSrc);
+            File.WriteAllText(Path.Combine(dirSrc, "file.txt"), "conteudo");
+
+            var dirPasta = Path.Combine(Path.GetTempPath(), "pmw-test-full-pasta-" + Guid.NewGuid());
+            Directory.CreateDirectory(dirPasta);
+            File.WriteAllText(Path.Combine(dirPasta, "pasta_file.txt"), "pasta");
+
+            try
+            {
+                var arquivos = new List<ArquivosDTO>
+                {
+                    new(Path.Combine(dirSrc, "file.txt"), "arquivos", false)
+                };
+                var pastas = new List<PastaDTO>
+                {
+                    new(dirPasta, "pastas_copiadas")
+                };
+                var comandos = new List<string> { "echo fim" };
+                var menuDto = new MenuDTO(_comandoId, "Completo", "completo", arquivos, pastas, comandos);
+                var repo = CriarRepositorio(new List<MenuDTO> { menuDto });
+                _repositorioJson.GetByIdAsync(_repositorioId).Returns(repo);
+
+                var resultado = await _sut.ExecutarComandoMenu(CriarMenu());
+
+                resultado.Should().BeTrue();
+
+                File.Exists(Path.Combine(_destinoDir, "arquivos", "file.txt")).Should().BeTrue();
+                Directory.Exists(Path.Combine(_destinoDir, "pastas_copiadas")).Should().BeTrue();
+                File.Exists(Path.Combine(_destinoDir, "pastas_copiadas", "pasta_file.txt")).Should().BeTrue();
+                _shell.Received(1).ExecutarComando(
+                    Arg.Is<string>(c => c.Contains("echo fim")),
+                    Arg.Any<string?>(),
+                    Arg.Any<string?>());
+            }
+            finally
+            {
+                if (Directory.Exists(dirSrc))
+                    Directory.Delete(dirSrc, true);
+                if (Directory.Exists(dirPasta))
+                    Directory.Delete(dirPasta, true);
+            }
+        }
+
+        [Fact]
+        public async Task Deve_ignorar_proximos_arquivos_quando_um_falha_mas_nao_interromper()
+        {
+            var dirSrc = Path.Combine(Path.GetTempPath(), "pmw-test-continuar-src-" + Guid.NewGuid());
+            Directory.CreateDirectory(dirSrc);
+            var arquivoValido = Path.Combine(dirSrc, "valido.txt");
+            File.WriteAllText(arquivoValido, "ok");
+
+            try
+            {
+                var arquivos = new List<ArquivosDTO>
+                {
+                    new("/caminho/inexistente/falha.exe", "sub", false),
+                    new(arquivoValido, "sub", false)
+                };
+                var menuDto = new MenuDTO(_comandoId, "Test", "arquivo", arquivos, null, null);
+                var repo = CriarRepositorio(new List<MenuDTO> { menuDto });
+                _repositorioJson.GetByIdAsync(_repositorioId).Returns(repo);
+
+                var resultado = await _sut.ExecutarComandoMenu(CriarMenu());
+
+                resultado.Should().BeTrue();
+
+                var destinoEsperado = Path.Combine(_destinoDir, "sub", "valido.txt");
+                File.Exists(destinoEsperado).Should().BeTrue();
+            }
+            finally
+            {
+                if (Directory.Exists(dirSrc))
+                    Directory.Delete(dirSrc, true);
+            }
+        }
+    }
 }

--- a/frontend/src/views/PastasView.vue
+++ b/frontend/src/views/PastasView.vue
@@ -682,13 +682,11 @@
   };
 
   const carregarPastas = async (): Promise<void> => {
-    pastas.value = [];
     try {
       const resposta = await carregandoAsync(async () => {
         return await PastasService.getPastas();
       });
 
-      // Garantir que os projetos sejam instâncias de ProjetoModel
       pastas.value = resposta.map((pasta: any) => {
         const pastaModel = new PastaModel(pasta);
         pastaModel.projetos =
@@ -751,7 +749,8 @@
   };
 
   const executarAcoes = async (): Promise<void> => {
-    // Executar ações do diretório (IDE/CLI)
+    localStorage.setItem(CHAVE_ABA_SELECIONADA, abaSelecionada.value);
+
     if (diretorioAcoes.value.includes('IDE')) {
       await abrirPastaNaIDE(pastaSelecionada.value as IPasta);
     }


### PR DESCRIPTION
## O que mudou

### `backend/src/Services/ComandoService.cs`
- Renomeado `IgnorarArquivoNoGit` → `AplicarSkipWorktree`
- Trocado `git update-index --assume-unchanged` por `--skip-worktree`
- Removida escrita no `.gitignore` (arquivo não rastreado não faz mais nada)
- Substituído `git ls-files --error-unmatch` por `git ls-files` (mais robusto)
- Substituído `ShellExecute.ExecutarComando` por `Process.Start` direto no git com wait e log de erro

### `backend/src/Services/RepositorioJsonService.cs`
- `GetByIdAsync` agora é `virtual` (necessário para mock nos testes)

### `backend/tests/ProjectManagerWeb.Tests/Services/ComandoServiceTests.cs`
- 13 novos testes para `ExecutarComandoMenu` cobrindo: cópia de arquivos com/sem IgnorarGit, diretório inexistente, pastas, comandos, falhas isoladas, token GitHub, destino com extensão

### `frontend/src/views/PastasView.vue`
- `executarAcoes` agora salva a aba atual no localStorage
- Removido `pastas.value = []` do `carregarPastas` (impedia o Vuetify de manter a aba selecionada ao atualizar)

## Como testar
1. Rodar `dotnet test` no backend — 119 testes, 0 falhas
2. Testar Aplicar arquivos com IgnorarGit=true em arquivo versionado → aplica skip-worktree
3. Testar Aplicar arquivos com IgnorarGit=true em arquivo não versionado → não mexe no .gitignore
4. Navegar entre abas, clicar em Executar → aba persiste ao recarregar a página
5. Clicar em Atualizar na lista de pastas → aba atual permanece selecionada