### PR TITLE
fix(release): adicionar bump-version como dependência do publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,7 +113,7 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
-    needs: [test-backend, build-frontend]
+    needs: [test-backend, build-frontend, bump-version]
     timeout-minutes: 15
     steps:
       - name: Checkout


### PR DESCRIPTION
## O que mudou

### `release.yml`
A job `publish` tinha `needs: [test-backend, build-frontend]`, sem incluir `bump-version`. No GitHub Actions, outputs de jobs só são acessíveis via `needs` se o job estiver listado diretamente. Como `bump-version` não estava no `needs`, a expressão `needs.bump-version.outputs.version` resolvia para **string vazia**, gerando releases com tag `v` e nome `PMW v` (sem número de versão).

**Correção:** adicionar `bump-version` ao `needs` do `publish`.

## Como testar
Após mergear, o próximo push na `main` deve gerar uma release com a versão correta (ex: `v1.0.16`, `PMW v1.0.16`)