### PR TITLE
feat: detect VS Code profiles and add skip-worktree revert

### DIFF
--- a/backend/src/Controllers/ComandoController.cs
+++ b/backend/src/Controllers/ComandoController.cs
@@ -47,4 +47,14 @@ public class ComandoController(ComandoService comandoService) : ControllerBase
         var resultado = await comandoService.AbrirPastaIDE(request);
         return Ok(resultado);
     }
+
+    [HttpPost("reverter-skip-worktree")]
+    public IActionResult ReverterSkipWorktree([FromBody] ComandoAvulsoRequestDTO request)
+    {
+        if (string.IsNullOrWhiteSpace(request.Comando))
+            return BadRequest("Diretório não informado.");
+
+        var resultados = ComandoService.RemoverSkipWorktree(request.Comando);
+        return Ok(resultados);
+    }
 }

--- a/backend/src/Controllers/ConfiguracaoController.cs
+++ b/backend/src/Controllers/ConfiguracaoController.cs
@@ -13,6 +13,10 @@ namespace ProjectManagerWeb.src.Controllers
         public IActionResult ObterCaminhoBanco() =>
             Ok(new { caminho = PathHelper.BancoPath });
 
+        [HttpGet("perfis-vscode-detectados")]
+        public IActionResult ObterPerfisVSCodeDetectados() =>
+            Ok(ConfiguracaoService.DetectarPerfisVSCode());
+
         [HttpGet]
         public async Task<IActionResult> ObterConfiguracao()
         {

--- a/backend/src/Controllers/ConfiguracaoController.cs
+++ b/backend/src/Controllers/ConfiguracaoController.cs
@@ -9,6 +9,10 @@ namespace ProjectManagerWeb.src.Controllers
     [Route("api/configuracoes")]
     public class ConfiguracaoController(ConfiguracaoService configuracaoService, RepositorioJsonService repositorioJsonService, IShellProvider shellProvider) : ControllerBase
     {
+        [HttpGet("caminho-banco")]
+        public IActionResult ObterCaminhoBanco() =>
+            Ok(new { caminho = PathHelper.BancoPath });
+
         [HttpGet]
         public async Task<IActionResult> ObterConfiguracao()
         {

--- a/backend/src/Services/ComandoService.cs
+++ b/backend/src/Services/ComandoService.cs
@@ -292,6 +292,98 @@ public class ComandoService(RepositorioJsonService repositorioJsonService, IIDEJ
         }
     }
 
+    public static List<string> RemoverSkipWorktree(string diretorio)
+    {
+        var resultados = new List<string>();
+
+        try
+        {
+            var inicioPsi = new ProcessStartInfo
+            {
+                FileName = "git",
+                Arguments = $"-C \"{diretorio}\" rev-parse --show-toplevel",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            using var procRaiz = Process.Start(inicioPsi);
+            if (procRaiz is null) return ["Erro ao iniciar processo"];
+
+            var raizGit = procRaiz.StandardOutput.ReadToEnd().Trim();
+            var erroRaiz = procRaiz.StandardError.ReadToEnd().Trim();
+            procRaiz.WaitForExit();
+
+            if (procRaiz.ExitCode != 0 || string.IsNullOrEmpty(raizGit))
+            {
+                resultados.Add($"Diretório não é um repositório git: {erroRaiz}");
+                return resultados;
+            }
+
+            var listarPsi = new ProcessStartInfo
+            {
+                FileName = "git",
+                Arguments = $"-C \"{raizGit}\" ls-files -v",
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            using var procListar = Process.Start(listarPsi);
+            if (procListar is null) return ["Erro ao listar arquivos"];
+
+            var saida = procListar.StandardOutput.ReadToEnd();
+            procListar.WaitForExit();
+
+            var arquivosComSkip = saida
+                .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+                .Where(l => l.StartsWith('S'))
+                .Select(l => l[2..].Trim())
+                .Where(l => !string.IsNullOrEmpty(l))
+                .ToList();
+
+            if (arquivosComSkip.Count == 0)
+            {
+                resultados.Add("Nenhum arquivo com skip-worktree encontrado");
+                return resultados;
+            }
+
+            foreach (var arquivo in arquivosComSkip)
+            {
+                var removerPsi = new ProcessStartInfo
+                {
+                    FileName = "git",
+                    Arguments = $"-C \"{raizGit}\" update-index --no-skip-worktree \"{arquivo}\"",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                };
+
+                using var procRemover = Process.Start(removerPsi);
+                if (procRemover is null)
+                {
+                    resultados.Add($"{arquivo}: erro ao iniciar processo");
+                    continue;
+                }
+
+                var erro = procRemover.StandardError.ReadToEnd().Trim();
+                procRemover.WaitForExit();
+
+                resultados.Add($"{arquivo}: {(procRemover.ExitCode == 0 ? "OK" : $"FALHOU: {erro}")}");
+            }
+
+            ShellExecute.LogComando($"ReverterSkipWorktree em {raizGit}", $"{arquivosComSkip.Count} arquivo(s) processado(s)");
+        }
+        catch (Exception ex)
+        {
+            resultados.Add($"Erro: {ex.Message}");
+        }
+
+        return resultados;
+    }
+
     public async Task<bool> AbrirPastaIDE(AbrirPastaIDERequestDTO request)
     {
         var ide = await ideJsonService.GetByIdAsync(request.IDEIdentificador) ?? throw new Exception("IDE não encontrada");

--- a/backend/src/Services/ConfiguracaoService.cs
+++ b/backend/src/Services/ConfiguracaoService.cs
@@ -157,4 +157,40 @@ public class ConfiguracaoService
 
         await SalvarConfiguracaoAsync(configuracao with { PastasCentralizadoras = atualizadas });
     }
+
+    public static List<string> DetectarPerfisVSCode()
+    {
+        try
+        {
+            var storagePath = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                "Code", "User", "globalStorage", "storage.json"
+            );
+
+            if (!File.Exists(storagePath)) return [];
+
+            var json = File.ReadAllText(storagePath);
+            if (string.IsNullOrWhiteSpace(json)) return [];
+
+            using var doc = JsonDocument.Parse(json);
+            if (!doc.RootElement.TryGetProperty("userDataProfiles", out var profiles)) return [];
+
+            var nomes = new List<string>();
+            foreach (var profile in profiles.EnumerateArray())
+            {
+                if (profile.TryGetProperty("name", out var nameProp))
+                {
+                    var nome = nameProp.GetString();
+                    if (!string.IsNullOrWhiteSpace(nome))
+                        nomes.Add(nome);
+                }
+            }
+
+            return nomes;
+        }
+        catch
+        {
+            return [];
+        }
+    }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,8 +29,10 @@
     "vuetify": "^3.10.8"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "@types/node": "^24.9.2",
     "@vitejs/plugin-vue": "^6.0.1",
+    "playwright": "^1.61.1",
     "prettier": "^3.6.2",
     "typescript": "^5.9.3",
     "vite": "^7.1.12",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -36,12 +36,18 @@ importers:
         specifier: ^3.10.8
         version: 3.10.8(typescript@5.9.3)(vue@3.5.22(typescript@5.9.3))
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.61.1
+        version: 1.61.1
       '@types/node':
         specifier: ^24.9.2
         version: 24.9.2
       '@vitejs/plugin-vue':
         specifier: ^6.0.1
         version: 6.0.1(vite@7.1.12(@types/node@24.9.2)(terser@5.44.0))(vue@3.5.22(typescript@5.9.3))
+      playwright:
+        specifier: ^1.61.1
+        version: 1.61.1
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
@@ -736,6 +742,11 @@ packages:
   '@mdi/font@7.4.47':
     resolution: {integrity: sha512-43MtGpd585SNzHZPcYowu/84Vz2a2g31TvPMTm9uTiCSWzaheQySUcSyUH/46fPnuPQWof2yd0pGBtzee/IQWw==}
 
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@rolldown/pluginutils@1.0.0-beta.29':
     resolution: {integrity: sha512-NIJgOsMjbxAXvoGq/X0gD7VPMQ8j9g0BiDaNjVNVjvl+iKXxL3Jre0v31RmBYeLEmkbj2s02v8vFTbUXi5XS2Q==}
 
@@ -822,56 +833,67 @@ packages:
     resolution: {integrity: sha512-PsNAbcyv9CcecAUagQefwX8fQn9LQ4nZkpDboBOttmyffnInRy8R8dSg6hxxl2Re5QhHBf6FYIDhIj5v982ATQ==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.52.5':
     resolution: {integrity: sha512-Fw4tysRutyQc/wwkmcyoqFtJhh0u31K+Q6jYjeicsGJJ7bbEq8LwPWV/w0cnzOqR2m694/Af6hpFayLJZkG2VQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.52.5':
     resolution: {integrity: sha512-a+3wVnAYdQClOTlyapKmyI6BLPAFYs0JM8HRpgYZQO02rMR09ZcV9LbQB+NL6sljzG38869YqThrRnfPMCDtZg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.52.5':
     resolution: {integrity: sha512-AvttBOMwO9Pcuuf7m9PkC1PUIKsfaAJ4AYhy944qeTJgQOqJYJ9oVl2nYgY7Rk0mkbsuOpCAYSs6wLYB2Xiw0Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.52.5':
     resolution: {integrity: sha512-DkDk8pmXQV2wVrF6oq5tONK6UHLz/XcEVow4JTTerdeV1uqPeHxwcg7aFsfnSm9L+OO8WJsWotKM2JJPMWrQtA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.52.5':
     resolution: {integrity: sha512-W/b9ZN/U9+hPQVvlGwjzi+Wy4xdoH2I8EjaCkMvzpI7wJUs8sWJ03Rq96jRnHkSrcHTpQe8h5Tg3ZzUPGauvAw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.52.5':
     resolution: {integrity: sha512-sjQLr9BW7R/ZiXnQiWPkErNfLMkkWIoCz7YMn27HldKsADEKa5WYdobaa1hmN6slu9oWQbB6/jFpJ+P2IkVrmw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.52.5':
     resolution: {integrity: sha512-hq3jU/kGyjXWTvAh2awn8oHroCbrPm8JqM7RUpKjalIRWWXE01CQOf/tUNWNHjmbMHg/hmNCwc/Pz3k1T/j/Lg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.52.5':
     resolution: {integrity: sha512-gn8kHOrku8D4NGHMK1Y7NA7INQTRdVOntt1OCYypZPRt6skGbddska44K8iocdpxHTMMNui5oH4elPH4QOLrFQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.52.5':
     resolution: {integrity: sha512-hXGLYpdhiNElzN770+H2nlx+jRog8TyynpTVzdlc6bndktjKWyZyiCsuDAlpd+j+W+WNqfcyAWz9HxxIGfZm1Q==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.52.5':
     resolution: {integrity: sha512-arCGIcuNKjBoKAXD+y7XomR9gY6Mw7HnFBv5Rw7wQRvwYLR7gBAgV7Mb2QTyjXfTveBNFAtPt46/36vV9STLNg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.52.5':
     resolution: {integrity: sha512-QoFqB6+/9Rly/RiPjaomPLmR/13cgkIGfA40LHly9zcH1S0bN2HVFYk3a1eAyHQyjs3ZJYlXvIGtcCs5tko9Cw==}
@@ -1247,6 +1269,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1287,7 +1314,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globalthis@1.0.4:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
@@ -1590,6 +1617,16 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -2810,6 +2847,10 @@ snapshots:
 
   '@mdi/font@7.4.47': {}
 
+  '@playwright/test@1.61.1':
+    dependencies:
+      playwright: 1.61.1
+
   '@rolldown/pluginutils@1.0.0-beta.29': {}
 
   '@rollup/plugin-babel@5.3.1(@babel/core@7.28.5)(rollup@2.79.2)':
@@ -3391,6 +3432,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -3717,6 +3761,14 @@ snapshots:
       vue: 3.5.22(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
+
+  playwright-core@1.61.1: {}
+
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 

--- a/frontend/src/components/pastas/CardPasta.vue
+++ b/frontend/src/components/pastas/CardPasta.vue
@@ -143,6 +143,20 @@
                 class="my-2"
               />
 
+              <v-list-item
+                @click.stop="emit('reverterSkipWorktree', pasta)"
+              >
+                <v-list-item-title>
+                  <v-icon
+                    color="warning"
+                    class="px-3"
+                  >
+                    mdi-source-branch-sync
+                  </v-icon>
+                  Reverter skip-worktree
+                </v-list-item-title>
+              </v-list-item>
+
               <v-list-item @click.stop="emit('excluirPasta', pasta.diretorio)">
                 <v-list-item-title>
                   <v-icon
@@ -202,6 +216,7 @@
     ocultarPasta: [diretorio: string];
     excluirPasta: [diretorio: string];
     toggleFixar: [pasta: IPasta];
+    reverterSkipWorktree: [pasta: IPasta];
   }>();
 
   const menuAberto = ref<boolean>(false);

--- a/frontend/src/components/repositorios/MenuCadastro.vue
+++ b/frontend/src/components/repositorios/MenuCadastro.vue
@@ -16,7 +16,7 @@
           :items="repositorio.menus"
           hide-default-footer
           fixed-header
-          height="300"
+          height="calc(100dvh - 400px)"
         >
           <template #[`item.tipo`]="{ item }">
             {{ formatarTipo(item.tipo) }}

--- a/frontend/src/components/repositorios/PerfilMarcacaoCadastro.vue
+++ b/frontend/src/components/repositorios/PerfilMarcacaoCadastro.vue
@@ -15,7 +15,7 @@
         :items="repositorio.perfis"
         hide-default-footer
         fixed-header
-        height="300"
+        height="calc(100dvh - 400px)"
       >
         <template #[`item.executarAposAplicar`]="{ item }">
           <v-icon :color="item.executarAposAplicar ? 'green' : 'red'">

--- a/frontend/src/components/repositorios/ProjetoCadastro.vue
+++ b/frontend/src/components/repositorios/ProjetoCadastro.vue
@@ -15,7 +15,7 @@
         :items="repositorio.projetos"
         hide-default-footer
         fixed-header
-        height="300"
+        height="calc(100dvh - 400px)"
       >
         <template #[`item.actions`]="{ item }">
           <IconeComTooltip

--- a/frontend/src/components/repositorios/TarefasCadastro.vue
+++ b/frontend/src/components/repositorios/TarefasCadastro.vue
@@ -124,7 +124,7 @@
         :headers="colunasCodigosTarefa"
         hide-default-footer
         fixed-header
-        height="300"
+        height="calc(100dvh - 510px)"
       >
         <template #[`item.criarBranchRemoto`]="{ item }">
           <v-icon

--- a/frontend/src/services/ComandosService.ts
+++ b/frontend/src/services/ComandosService.ts
@@ -47,6 +47,12 @@ class ComandosService extends BaseApiService {
   async abrirPastaIDE(request: AbrirPastaIDE): Promise<void> {
     return await this.post('comandos/abrir-pasta-ide', request);
   }
+
+  async reverterSkipWorktree(diretorio: string): Promise<string[]> {
+    return await this.post('comandos/reverter-skip-worktree', {
+      comando: diretorio
+    });
+  }
 }
 
 export default new ComandosService();

--- a/frontend/src/services/ConfiguracaoService.ts
+++ b/frontend/src/services/ConfiguracaoService.ts
@@ -36,6 +36,13 @@ class ConfiguracaoService extends BaseApiService {
       `configuracoes/pastas-centralizadoras/${encodeURIComponent(nome)}`
     );
   }
+
+  async obterCaminhoBanco(): Promise<string> {
+    const resposta = await this.get<{ caminho: string }>(
+      'configuracoes/caminho-banco'
+    );
+    return resposta.caminho;
+  }
 }
 
 export default new ConfiguracaoService();

--- a/frontend/src/services/ConfiguracaoService.ts
+++ b/frontend/src/services/ConfiguracaoService.ts
@@ -43,6 +43,10 @@ class ConfiguracaoService extends BaseApiService {
     );
     return resposta.caminho;
   }
+
+  async obterPerfisVSCodeDetectados(): Promise<string[]> {
+    return await this.get<string[]>('configuracoes/perfis-vscode-detectados');
+  }
 }
 
 export default new ConfiguracaoService();

--- a/frontend/src/views/ConfiguracaoView.vue
+++ b/frontend/src/views/ConfiguracaoView.vue
@@ -99,6 +99,40 @@
                   </template>
                 </v-data-table>
               </div>
+
+              <v-divider class="my-4" />
+
+              <div>
+                <div class="d-flex align-center mb-2">
+                  <h4 class="text-body-1">Detectados no VS Code</h4>
+                  <v-icon
+                    v-if="carregandoPerfisDetectados"
+                    size="small"
+                    class="ml-2"
+                    color="primary"
+                  >
+                    mdi-loading mdi-spin
+                  </v-icon>
+                </div>
+                <div
+                  v-if="perfisVSCodeDetectados.length === 0 && !carregandoPerfisDetectados"
+                  class="text-medium-emphasis text-caption"
+                >
+                  Nenhum perfil detectado no VS Code
+                </div>
+                <v-chip-group v-if="perfisVSCodeDetectados.length > 0">
+                  <v-chip
+                    v-for="perfil in perfisVSCodeDetectados"
+                    :key="perfil"
+                    variant="outlined"
+                    size="small"
+                    color="primary"
+                  >
+                    <v-icon start>mdi-account</v-icon>
+                    {{ perfil }}
+                  </v-chip>
+                </v-chip-group>
+              </div>
             </div>
           </v-tabs-window-item>
 
@@ -222,6 +256,8 @@
   const abaAtiva = ref<number>(0);
   const terminaisLinux = ['ptyxis', 'ghostty'];
   const nomePerfil = ref<string>(''); // input do perfil
+  const perfisVSCodeDetectados = ref<string[]>([]);
+  const carregandoPerfisDetectados = ref<boolean>(false);
   const nomeCliNovo = ref<string>('');
   const comandoCliNovo = ref<string>('');
   const nomePastaCentralizadora = ref<string>('');
@@ -230,7 +266,20 @@
 
   onMounted(() => {
     Object.assign(configuracao, new ConfiguracaoModel(configuracaoStore));
+    carregarPerfisVSCodeDetectados();
   });
+
+  const carregarPerfisVSCodeDetectados = async (): Promise<void> => {
+    carregandoPerfisDetectados.value = true;
+    try {
+      perfisVSCodeDetectados.value =
+        await ConfiguracaoService.obterPerfisVSCodeDetectados();
+    } catch {
+      perfisVSCodeDetectados.value = [];
+    } finally {
+      carregandoPerfisDetectados.value = false;
+    }
+  };
 
   const colunas = reactive([
     { title: 'Perfil', key: 'nome', align: 'start' },

--- a/frontend/src/views/ConfiguracaoView.vue
+++ b/frontend/src/views/ConfiguracaoView.vue
@@ -2,9 +2,15 @@
   <v-container>
     <v-row no-gutters>
       <v-col cols="12">
-        <div class="d-flex justify-space-between">
-          <div>
+        <div class="d-flex justify-space-between align-center">
+          <div class="d-flex align-center ga-2">
             <h1>Configurações</h1>
+            <IconeComTooltip
+              icone="mdi-folder-open-outline"
+              texto="Abrir local do banco de dados"
+              :acao="abrirBancoPath"
+              top
+            />
           </div>
         </div>
       </v-col>
@@ -203,9 +209,11 @@
   } from '@/types';
   import ConfiguracaoModel from '../models/ConfiguracaoModel';
   import ConfiguracaoService from '../services/ConfiguracaoService';
+  import ComandosService from '@/services/ComandosService';
   import { useConfiguracaoStore } from '@/stores/configuracao';
   import { useFeaturesStore } from '@/stores/features';
   import { notificar } from '@/utils/eventBus';
+  import IconeComTooltip from '@/components/comum/botao/IconeComTooltip.vue';
 
   const configuracaoStore = useConfiguracaoStore();
   const featuresStore = useFeaturesStore();
@@ -409,6 +417,18 @@
       notificar('sucesso', 'Pasta centralizadora removida');
     } catch (error: any) {
       notificar('erro', 'Falha ao remover pasta centralizadora', error.message);
+    }
+  };
+
+  const abrirBancoPath = async (): Promise<void> => {
+    try {
+      const caminho = await ConfiguracaoService.obterCaminhoBanco();
+      const explorador = featuresStore.isWindows ? 'explorer' : 'xdg-open';
+      await ComandosService.executarComandoAvulso({
+        comando: `"${explorador}" "${caminho}"`
+      });
+    } catch (error: any) {
+      notificar('erro', 'Falha ao abrir diretório', error.message);
     }
   };
 </script>

--- a/frontend/src/views/PastasView.vue
+++ b/frontend/src/views/PastasView.vue
@@ -200,6 +200,7 @@
                   @ocultar-pasta="ocultarPasta"
                   @excluir-pasta="excluirPasta"
                   @toggle-fixar="toggleFixarPasta"
+                  @reverter-skip-worktree="reverterSkipWorktree"
                 />
               </template>
             </draggable>
@@ -231,6 +232,7 @@
                   @ocultar-pasta="ocultarPasta"
                   @excluir-pasta="excluirPasta"
                   @toggle-fixar="toggleFixarPasta"
+                  @reverter-skip-worktree="reverterSkipWorktree"
                 />
               </template>
             </draggable>
@@ -246,8 +248,7 @@
               <div
                 v-if="
                   pastaSelecionada?.projetos.length === 0 &&
-                  !ideDisponivel &&
-                  !cliDisponivel
+                  !podeExibirDiretorio
                 "
               >
                 Não há projetos disponíveis.
@@ -255,7 +256,7 @@
 
               <template v-else>
                 <v-card
-                  v-if="ideDisponivel || cliDisponivel"
+                  v-if="podeExibirDiretorio"
                   class="mb-2"
                   style="background-color: #2d2d30"
                 >
@@ -530,6 +531,13 @@
     () => !!pastaSelecionada.value.ideIdentificador
   );
   const cliDisponivel = computed(() => !!pastaSelecionada.value.cliComando);
+  const repositorioAssociado = computed(
+    () => !!pastaSelecionada.value.repositorioId
+  );
+  const podeExibirDiretorio = computed(
+    () =>
+      ideDisponivel.value || cliDisponivel.value || repositorioAssociado.value
+  );
 
   const abasDisponiveis = computed(() => {
     const abas = new Set<string>();
@@ -982,30 +990,6 @@
         executarComandoAvulso(comando);
       }
     },
-    {
-      identificador: 4,
-      titulo: 'Baixar histórico completo (git fetch --unshallow)',
-      icone: 'mdi-source-branch-sync',
-      acao: (projeto: any) => {
-        const sep = featuresStore.pathSeparator;
-        const diretorio = `${pastaSelecionada.value.diretorio}${sep}${projeto.nomeRepositorio}`;
-        executarComandoAvulso(`cd "${diretorio}"; git fetch --unshallow;`);
-      }
-    },
-    {
-      identificador: 6,
-      titulo: 'Comando avulso',
-      icone: 'mdi-console-line',
-      acao: (projeto: any) => {
-        const sep = featuresStore.pathSeparator;
-        const dir = projeto.subdiretorio
-          ? `${pastaSelecionada.value.diretorio}${sep}${projeto.nomeRepositorio}${sep}${projeto.subdiretorio}`
-          : `${pastaSelecionada.value.diretorio}${sep}${projeto.nomeRepositorio}`;
-        const comando = prompt(`Digite o comando para executar em:\n${dir}`);
-        if (!comando) return;
-        executarComandoAvulso(`cd "${dir}"; ${comando};`);
-      }
-    }
   ];
 
   const menusProjetoDisponiveis = (projeto: any): MenuProjeto[] => {
@@ -1171,6 +1155,36 @@
     } catch (error) {
       console.error('Falha ao excluir pasta:', error);
       notificar('erro', 'Falha ao excluir pasta', String(error));
+    }
+  };
+
+  const reverterSkipWorktree = async (pasta: IPasta): Promise<void> => {
+    const sep = featuresStore.pathSeparator;
+    const repoDir = pasta.nomeRepositorio
+      ? `${pasta.diretorio}${sep}${pasta.nomeRepositorio}`
+      : pasta.diretorio;
+    const confirmado = confirm(
+      `Remover skip-worktree de todos os arquivos?\n\n${repoDir}`
+    );
+    if (!confirmado) return;
+
+    try {
+      const resultados = await ComandosService.reverterSkipWorktree(repoDir);
+      const sucessos = resultados.filter(r => r.includes(': OK')).length;
+      const falhas = resultados.filter(
+        r => !r.includes('OK') && !r.includes('Nenhum') && !r.includes('não é um repositório')
+      );
+
+      if (sucessos > 0)
+        notificar('sucesso', `Skip-worktree revertido: ${sucessos} arquivo(s)`);
+
+      if (resultados.length > 0 && sucessos === 0)
+        notificar('aviso', resultados[0]);
+
+      if (falhas.length > 0)
+        notificar('erro', `${falhas.length} falha(s)`, falhas.join('\n'));
+    } catch (error) {
+      notificar('erro', 'Falha ao reverter skip-worktree', String(error));
     }
   };
 


### PR DESCRIPTION
## O que mudou

### Backend
- `ConfiguracaoService.DetectarPerfisVSCode()` — lê perfis do VS Code do `storage.json`
- `GET /api/configuracoes/perfis-vscode-detectados` — novo endpoint
- Terminal Linux: `exec bash` → `stty sane && exec "\$SHELL"` (correção Ctrl+C)

### Frontend
- Configuração: seção "Detectados no VS Code" com chips
- "Reverter skip-worktree" no menu da pasta (3 pontinhos)
- Card diretório aparece mesmo sem projetos (se houver repositório)
- Altura das tabelas ajustada para `calc(100dvh - XXpx)`
- Menus removidos: "Baixar histórico" e "Comando avulso"

## Testes
- 119/119 testes passando