### PR TITLE
feat: select inteligente de perfil IDE com detecção automática

### DIFF
--- a/backend/src/Controllers/ConfiguracaoController.cs
+++ b/backend/src/Controllers/ConfiguracaoController.cs
@@ -13,9 +13,17 @@ namespace ProjectManagerWeb.src.Controllers
         public IActionResult ObterCaminhoBanco() =>
             Ok(new { caminho = PathHelper.BancoPath });
 
-        [HttpGet("perfis-vscode-detectados")]
-        public IActionResult ObterPerfisVSCodeDetectados() =>
-            Ok(ConfiguracaoService.DetectarPerfisVSCode());
+        [HttpGet("perfis-ide")]
+        public IActionResult ObterPerfisIDE([FromQuery] string? ide)
+        {
+            var perfis = ide?.ToLower() switch
+            {
+                "vs code" => ConfiguracaoService.DetectarPerfisVSCode(),
+                "kiro" => ConfiguracaoService.DetectarPerfisKiro(),
+                _ => []
+            };
+            return Ok(perfis);
+        }
 
         [HttpGet]
         public async Task<IActionResult> ObterConfiguracao()

--- a/backend/src/Services/ConfiguracaoService.cs
+++ b/backend/src/Services/ConfiguracaoService.cs
@@ -158,13 +158,19 @@ public class ConfiguracaoService
         await SalvarConfiguracaoAsync(configuracao with { PastasCentralizadoras = atualizadas });
     }
 
-    public static List<string> DetectarPerfisVSCode()
+    public static List<string> DetectarPerfisVSCode() =>
+        LerPerfisIde("Code");
+
+    public static List<string> DetectarPerfisKiro() =>
+        LerPerfisIde("Kiro");
+
+    private static List<string> LerPerfisIde(string ideFolder)
     {
         try
         {
             var storagePath = Path.Combine(
                 Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-                "Code", "User", "globalStorage", "storage.json"
+                ideFolder, "User", "globalStorage", "storage.json"
             );
 
             if (!File.Exists(storagePath)) return [];

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -184,7 +184,10 @@
           </v-icon>
         </v-btn>
 
-        <v-menu close-on-content-click="false">
+        <v-menu
+          v-model="menuAtualizacaoAberto"
+          close-on-content-click="false"
+        >
           <template v-slot:activator="{ props }">
             <v-btn
               icon
@@ -246,7 +249,7 @@
 
             <v-list-item
               v-if="versaoStore.temAtualizacao"
-              @click="atualizarAgora"
+              @click.stop="atualizarAgora"
             >
               <v-list-item-title class="text-body-2">
                 <v-icon
@@ -260,7 +263,7 @@
               </v-list-item-title>
             </v-list-item>
 
-            <v-list-item @click="verificarAtualizacaoManual">
+            <v-list-item @click.stop="menuAtualizacaoAberto = true; verificarAtualizacaoManual()">
               <v-list-item-title class="text-body-2">
                 <v-icon
                   size="small"
@@ -381,10 +384,13 @@
     await versaoStore.verificarAtualizacao();
     if (versaoStore.erro)
       notificar('erro', 'Falha ao verificar atualizações', versaoStore.erro);
-    else if (!versaoStore.temAtualizacao)
+    else if (versaoStore.temAtualizacao)
+      notificar('sucesso', `Nova versão disponível: ${versaoStore.versaoNova}`);
+    else
       notificar('sucesso', 'Você está na versão mais recente');
   };
 
+  const menuAtualizacaoAberto = ref(false);
   const exibirCarregando = ref(true);
   const exibirConteudoCarregando = ref(false);
   const mensagem = ref('Carregando...');

--- a/frontend/src/components/comum/SelectPerfilIDE.vue
+++ b/frontend/src/components/comum/SelectPerfilIDE.vue
@@ -1,0 +1,56 @@
+<template>
+  <v-select
+    label="Perfil da IDE"
+    v-model="perfil"
+    :items="perfis"
+    :loading="carregando"
+    :disabled="!ideNome"
+    clearable
+    hint="Perfil usado ao abrir o projeto na IDE"
+    persistent-hint
+  />
+</template>
+
+<script setup lang="ts">
+  import { computed, ref, watch } from 'vue';
+  import ConfiguracaoService from '@/services/ConfiguracaoService';
+
+  const perfil = defineModel<string | null>({ default: null });
+
+  const props = withDefaults(
+    defineProps<{
+      ideIdentificador?: string | null;
+      ides: { identificador: string; nome: string }[];
+    }>(),
+    { ideIdentificador: null }
+  );
+
+  const perfis = ref<string[]>([]);
+  const carregando = ref(false);
+
+  const ideNome = computed((): string | null => {
+    if (!props.ideIdentificador) return null;
+    const ide = props.ides.find(
+      i => i.identificador === props.ideIdentificador
+    );
+    return ide?.nome || null;
+  });
+
+  watch(ideNome, async novoNome => {
+    if (!novoNome) {
+      perfis.value = [];
+      perfil.value = null;
+      return;
+    }
+
+    carregando.value = true;
+    try {
+      perfis.value = await ConfiguracaoService.obterPerfisIDE(novoNome);
+      if (perfis.value.length === 0) perfil.value = null;
+    } catch {
+      perfis.value = [];
+    } finally {
+      carregando.value = false;
+    }
+  });
+</script>

--- a/frontend/src/components/pastas/CardPasta.vue
+++ b/frontend/src/components/pastas/CardPasta.vue
@@ -143,9 +143,7 @@
                 class="my-2"
               />
 
-              <v-list-item
-                @click.stop="emit('reverterSkipWorktree', pasta)"
-              >
+              <v-list-item @click.stop="emit('reverterSkipWorktree', pasta)">
                 <v-list-item-title>
                   <v-icon
                     color="warning"

--- a/frontend/src/components/repositorios/IDETerminalCadastro.vue
+++ b/frontend/src/components/repositorios/IDETerminalCadastro.vue
@@ -33,15 +33,10 @@
       cols="12"
       class="mb-4"
     >
-      <v-select
-        :items="configuracaoStore.perfisVSCode"
-        label="Perfil da IDE"
+      <SelectPerfilIDE
         v-model="repositorio.perfilVSCode"
-        item-title="nome"
-        item-value="nome"
-        clearable
-        hint="Perfil usado ao abrir a pasta raiz do repositório na IDE"
-        persistent-hint
+        :ide-identificador="repositorio.ideIdentificador"
+        :ides="ides"
       />
     </v-col>
 
@@ -91,6 +86,7 @@
   import type { IRepositorio, IIDE } from '@/types';
   import IDEsService from '@/services/IDEsService';
   import { useConfiguracaoStore } from '@/stores/configuracao';
+  import SelectPerfilIDE from '@/components/comum/SelectPerfilIDE.vue';
   import SelectPerfilTerminal from '@/components/comum/SelectPerfilTerminal.vue';
 
   const repositorio = defineModel<IRepositorio>({ required: true });

--- a/frontend/src/components/repositorios/ProjetoCadastro.vue
+++ b/frontend/src/components/repositorios/ProjetoCadastro.vue
@@ -59,12 +59,12 @@
             v-model="projetoSelecionado.subdiretorio"
             autocomplete="off"
           />
-          <v-select
-            :items="configuracaoStore.perfisVSCode"
-            label="Perfil VS Code"
+          <SelectPerfilIDE
             v-model="projetoSelecionado.perfilVSCode"
-            item-title="nome"
-            item-value="nome"
+            :ide-identificador="
+              projetoSelecionado.comandosObj!.ideIdentificador
+            "
+            :ides="ides"
           />
 
           <v-text-field
@@ -120,6 +120,7 @@
   import { useModoOperacao } from '@/composables/useModoOperacao';
   import { TIPO_COMANDO } from '@/constants/geral-constants';
   import IDEsService from '@/services/IDEsService';
+  import SelectPerfilIDE from '@/components/comum/SelectPerfilIDE.vue';
   import SelectPerfilTerminal from '@/components/comum/SelectPerfilTerminal.vue';
   import { notificar } from '@/utils/eventBus';
 

--- a/frontend/src/services/ConfiguracaoService.ts
+++ b/frontend/src/services/ConfiguracaoService.ts
@@ -44,8 +44,10 @@ class ConfiguracaoService extends BaseApiService {
     return resposta.caminho;
   }
 
-  async obterPerfisVSCodeDetectados(): Promise<string[]> {
-    return await this.get<string[]>('configuracoes/perfis-vscode-detectados');
+  async obterPerfisIDE(ideNome: string): Promise<string[]> {
+    return await this.get<string[]>(
+      `configuracoes/perfis-ide?ide=${encodeURIComponent(ideNome)}`
+    );
   }
 }
 

--- a/frontend/src/views/ConfiguracaoView.vue
+++ b/frontend/src/views/ConfiguracaoView.vue
@@ -18,7 +18,6 @@
       <v-col cols="12">
         <v-tabs v-model="abaAtiva">
           <v-tab>Geral</v-tab>
-          <v-tab>Perfis IDE</v-tab>
           <v-tab>Pasta Centralizadora</v-tab>
           <v-tab>CLI de IA</v-tab>
         </v-tabs>
@@ -55,85 +54,6 @@
                 />
               </v-col>
             </v-row>
-          </v-tabs-window-item>
-
-          <!-- Aba: Perfis IDE -->
-          <v-tabs-window-item>
-            <div class="d-flex flex-column justify-center pt-4">
-              <div class="d-flex align-center">
-                <v-text-field
-                  label="Perfil"
-                  v-model="nomePerfil"
-                  autocomplete="off"
-                  name="pmw-perfil"
-                  @keydown.enter.prevent="adicionarPerfil"
-                />
-                <v-btn
-                  class="ml-2"
-                  @click="adicionarPerfil"
-                >
-                  <v-icon>mdi-plus</v-icon>
-                  Adicionar
-                </v-btn>
-              </div>
-
-              <div>
-                <v-data-table
-                  :items="configuracao.perfisVSCode"
-                  :headers="colunas"
-                  hide-default-footer
-                >
-                  <template #[`item.actions`]="{ item }">
-                    <IconeComTooltip
-                      icone="mdi-pencil"
-                      texto="Editar"
-                      :acao="() => editarPerfil(item)"
-                      top
-                    />
-                    <IconeComTooltip
-                      icone="mdi-delete"
-                      texto="Excluir"
-                      :acao="() => removerPerfil(item)"
-                      top
-                    />
-                  </template>
-                </v-data-table>
-              </div>
-
-              <v-divider class="my-4" />
-
-              <div>
-                <div class="d-flex align-center mb-2">
-                  <h4 class="text-body-1">Detectados no VS Code</h4>
-                  <v-icon
-                    v-if="carregandoPerfisDetectados"
-                    size="small"
-                    class="ml-2"
-                    color="primary"
-                  >
-                    mdi-loading mdi-spin
-                  </v-icon>
-                </div>
-                <div
-                  v-if="perfisVSCodeDetectados.length === 0 && !carregandoPerfisDetectados"
-                  class="text-medium-emphasis text-caption"
-                >
-                  Nenhum perfil detectado no VS Code
-                </div>
-                <v-chip-group v-if="perfisVSCodeDetectados.length > 0">
-                  <v-chip
-                    v-for="perfil in perfisVSCodeDetectados"
-                    :key="perfil"
-                    variant="outlined"
-                    size="small"
-                    color="primary"
-                  >
-                    <v-icon start>mdi-account</v-icon>
-                    {{ perfil }}
-                  </v-chip>
-                </v-chip-group>
-              </div>
-            </div>
           </v-tabs-window-item>
 
           <!-- Aba: Pasta Centralizadora -->
@@ -236,11 +156,7 @@
 
 <script setup lang="ts">
   import { onMounted, reactive, ref, nextTick } from 'vue';
-  import type {
-    IConfiguracao,
-    IPastaCentralizadora,
-    IPerfilVSCode
-  } from '@/types';
+  import type { IConfiguracao, IPastaCentralizadora } from '@/types';
   import ConfiguracaoModel from '../models/ConfiguracaoModel';
   import ConfiguracaoService from '../services/ConfiguracaoService';
   import ComandosService from '@/services/ComandosService';
@@ -255,9 +171,7 @@
   // --- STATE ---
   const abaAtiva = ref<number>(0);
   const terminaisLinux = ['ptyxis', 'ghostty'];
-  const nomePerfil = ref<string>(''); // input do perfil
-  const perfisVSCodeDetectados = ref<string[]>([]);
-  const carregandoPerfisDetectados = ref<boolean>(false);
+
   const nomeCliNovo = ref<string>('');
   const comandoCliNovo = ref<string>('');
   const nomePastaCentralizadora = ref<string>('');
@@ -266,25 +180,7 @@
 
   onMounted(() => {
     Object.assign(configuracao, new ConfiguracaoModel(configuracaoStore));
-    carregarPerfisVSCodeDetectados();
   });
-
-  const carregarPerfisVSCodeDetectados = async (): Promise<void> => {
-    carregandoPerfisDetectados.value = true;
-    try {
-      perfisVSCodeDetectados.value =
-        await ConfiguracaoService.obterPerfisVSCodeDetectados();
-    } catch {
-      perfisVSCodeDetectados.value = [];
-    } finally {
-      carregandoPerfisDetectados.value = false;
-    }
-  };
-
-  const colunas = reactive([
-    { title: 'Perfil', key: 'nome', align: 'start' },
-    { title: 'Actions', key: 'actions', align: 'center', width: '200px' }
-  ] as const);
 
   const colunasCli = reactive([
     { title: 'Nome', key: 'nome', align: 'start' },
@@ -304,66 +200,6 @@
       notificar('sucesso', 'Configurações atualizadas');
     } catch (error: any) {
       notificar('erro', 'Falha ao salvar configuração', error.message);
-    }
-  };
-
-  // Valida nome do perfil
-  const perfilValido = (): boolean => {
-    if (!nomePerfil.value.trim()) {
-      alert('O nome do perfil é obrigatório');
-      return false;
-    }
-
-    const jaInformado = configuracao.perfisVSCode?.some(
-      p => p.nome === nomePerfil.value
-    );
-
-    if (jaInformado) {
-      alert('Já existe um perfil com esse nome');
-      return false;
-    }
-
-    return true;
-  };
-
-  // Adiciona perfil
-  const adicionarPerfil = (): void => {
-    if (!perfilValido()) return;
-
-    configuracao.perfisVSCode.push({ nome: nomePerfil.value });
-    nomePerfil.value = ''; // limpa input
-
-    salvarConfiguracao(); // opcional, salva direto
-  };
-
-  const editarPerfil = async (item: IPerfilVSCode): Promise<void> => {
-    const novoNome = prompt('Editar nome do perfil:', item.nome);
-    if (!novoNome || !novoNome.trim()) return;
-
-    const nomeAntigo = item.nome;
-    const nomeTrimado = novoNome.trim();
-
-    try {
-      await ConfiguracaoService.renomearPerfil(nomeAntigo, nomeTrimado);
-      item.nome = nomeTrimado;
-      configuracaoStore.salvarConfiguracao(configuracao);
-      notificar(
-        'sucesso',
-        'Perfil renomeado e atualizado em todos os projetos'
-      );
-    } catch (error: any) {
-      notificar('erro', 'Falha ao renomear perfil', error.message);
-    }
-  };
-
-  // Remover perfil
-  const removerPerfil = (item: IPerfilVSCode): void => {
-    const confirmDelete = confirm(`Deseja remover o perfil "${item.nome}"?`);
-    if (confirmDelete) {
-      configuracao.perfisVSCode = configuracao.perfisVSCode.filter(
-        p => p !== item
-      );
-      salvarConfiguracao();
     }
   };
 

--- a/frontend/src/views/PastasView.vue
+++ b/frontend/src/views/PastasView.vue
@@ -1,6 +1,7 @@
 <template>
-  <v-container>
-    <div class="d-flex flex-column">
+  <v-row class="d-flex justify-center pt-5 px-6">
+    <v-col cols="12" lg="10">
+      <div class="d-flex flex-column">
       <v-row no-gutters>
         <v-col
           cols="8"
@@ -446,8 +447,8 @@
         </v-col>
       </v-row>
     </div>
-  </v-container>
-
+    </v-col>
+  </v-row>
   <CadastroPasta
     v-model="exibirModalPasta"
     :pasta="pastaSelecionada"

--- a/frontend/src/views/PastasView.vue
+++ b/frontend/src/views/PastasView.vue
@@ -989,7 +989,7 @@
           : `cd "${dir}";`;
         executarComandoAvulso(comando);
       }
-    },
+    }
   ];
 
   const menusProjetoDisponiveis = (projeto: any): MenuProjeto[] => {
@@ -1172,7 +1172,10 @@
       const resultados = await ComandosService.reverterSkipWorktree(repoDir);
       const sucessos = resultados.filter(r => r.includes(': OK')).length;
       const falhas = resultados.filter(
-        r => !r.includes('OK') && !r.includes('Nenhum') && !r.includes('não é um repositório')
+        r =>
+          !r.includes('OK') &&
+          !r.includes('Nenhum') &&
+          !r.includes('não é um repositório')
       );
 
       if (sucessos > 0)


### PR DESCRIPTION
## O que mudou

### Backend
- `ConfiguracaoController.cs`: endpoint unificado `GET /api/configuracoes/perfis-ide?ide=...`
- `ConfiguracaoService.cs`: `LerPerfisIde(ideFolder)` reutilizável entre VS Code e Kiro

### Frontend — SelectPerfilIDE.vue
- Select inteligente que carrega perfis da IDE selecionada
- Vinculado ao select de IDE — trocou de IDE, carrega automaticamente

### Integrações
- `IDETerminalCadastro.vue`: campo "Perfil da IDE" usa `SelectPerfilIDE`
- `ProjetoCadastro.vue": campo "Perfil VS Code" usa `SelectPerfilIDE`
- `ConfiguracaoView.vue`: aba "Perfis IDE" removida (detecção automática substituiu CRUD)
- `App.vue`: menu de atualização não fecha ao verificar + notifica nova versão

## Testes
- 119/119 testes passando