### PR TITLE
feat: duplicar item no menu de contexto e fechar menu ao excluir pasta

### DIFF
--- a/frontend/src/components/pastas/CardPasta.vue
+++ b/frontend/src/components/pastas/CardPasta.vue
@@ -143,7 +143,9 @@
                 class="my-2"
               />
 
-              <v-list-item @click.stop="emit('reverterSkipWorktree', pasta)">
+              <v-list-item
+                @click.stop="menuAberto = false; emit('reverterSkipWorktree', pasta)"
+              >
                 <v-list-item-title>
                   <v-icon
                     color="warning"
@@ -155,7 +157,9 @@
                 </v-list-item-title>
               </v-list-item>
 
-              <v-list-item @click.stop="emit('excluirPasta', pasta.diretorio)">
+              <v-list-item
+                @click.stop="menuAberto = false; emit('excluirPasta', pasta.diretorio)"
+              >
                 <v-list-item-title>
                   <v-icon
                     color="error"

--- a/frontend/src/components/repositorios/MenuCadastro.vue
+++ b/frontend/src/components/repositorios/MenuCadastro.vue
@@ -400,7 +400,8 @@
 
   const duplicarItem = (item: IMenu): void => {
     definirModoCadastro();
-    Object.assign(menuSelecionado, new MenuModel(item));
+    const copia = { ...item, identificador: crypto.randomUUID() };
+    Object.assign(menuSelecionado, new MenuModel(copia));
     abrirModalMenuCadastro();
     nextTick(() => campoTitulo.value?.focus());
   };

--- a/frontend/src/components/repositorios/MenuCadastro.vue
+++ b/frontend/src/components/repositorios/MenuCadastro.vue
@@ -34,6 +34,12 @@
               top
             />
             <IconeComTooltip
+              icone="mdi-content-copy"
+              texto="Duplicar"
+              :acao="() => duplicarItem(item)"
+              top
+            />
+            <IconeComTooltip
               icone="mdi-delete"
               texto="Excluir"
               :acao="() => excluirProjeto(item)"
@@ -390,6 +396,13 @@
     Object.assign(menuSelecionado, item);
     definirModoEdicao();
     abrirModalMenuCadastro();
+  };
+
+  const duplicarItem = (item: IMenu): void => {
+    definirModoCadastro();
+    Object.assign(menuSelecionado, new MenuModel(item));
+    abrirModalMenuCadastro();
+    nextTick(() => campoTitulo.value?.focus());
   };
 
   const formProjeto = ref<any>(null);


### PR DESCRIPTION
## O que mudou

### `MenuCadastro.vue`
- Novo ícone de Duplicar (📋) na coluna Actions da tabela
- Ao clicar, abre o modal em modo cadastro com os dados do item preenchidos e novo UUID
- Correção: UUID duplicado — agora gera `crypto.randomUUID()` explicitamente

### `CardPasta.vue`
- "Excluir pasta" e "Reverter skip-worktree" no menu agora fecham o menu antes de executar a ação

## Testes
- 119/119 testes passando
- Build sem erros